### PR TITLE
Run integration tests by re-using the CI build results

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -28,9 +28,13 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+      - name: Pack build artifacts for upload
+        shell: bash
+        run: tar -czvf mc-java-ci-build-results.tar.gz ./*
+
       - name: Upload build results
         uses: actions/upload-artifact@v2
         with:
           name: mc-java-ci-build-results
-          path: ./*
+          path: mc-java-ci-build-results.tar.gz
           retention-days: 1

--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -27,3 +27,10 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+
+      - name: Upload build results
+        uses: actions/upload-artifact@v2
+        with:
+          name: mc-java-ci-build-results
+          path: ./*
+          retention-days: 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,10 +27,10 @@ jobs:
         shell: bash
         run: tar -xzvf mc-java-ci-build-results.tar.gz
 
-#      - name: Run tests
-#        shell: bash
-#        run: |
-#          pwd
-#          ls
-#          cd tests
-#          ./gradlew build --stacktrace
+      - name: Run tests
+        shell: bash
+        run: |
+          pwd
+          ls
+          cd tests
+          ./gradlew build --stacktrace

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,9 +14,10 @@ jobs:
         # This custom action allows downloading the `actions/upload-artifact@v2` results.
         uses: dawidd6/action-download-artifact@v2
         with:
-          - github_token: ${{ secrets.GITHUB_TOKEN }}
-          - name: mc-java-ci-build-results.tar.gz
-          - path: ./
+          workflow: build-on-ubuntu.yml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          name: mc-java-ci-build-results
+          path: ./
 
       - name: Unpack the downloaded file
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Download CI build results
+        # This custom action allows downloading the `actions/upload-artifact@v2` results.
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          - github_token: ${{ secrets.GITHUB_TOKEN }}
+          - name: mc-java-ci-build-results
+          - path: ./
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,8 +15,13 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           - github_token: ${{ secrets.GITHUB_TOKEN }}
-          - name: mc-java-ci-build-results
+          - name: mc-java-ci-build-results.tar.gz
           - path: ./
+
+      - name: Unpack the downloaded file
+        shell: bash
+        run: tar -xzvf mc-java-ci-build-results.tar.gz
+
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Print status message
+        shell: bash
+        run: echo "Downloading CI build results..."
+
       - name: Download CI build results
         # This custom action allows downloading the `actions/upload-artifact@v2` results.
         uses: dawidd6/action-download-artifact@v2
@@ -23,10 +27,10 @@ jobs:
         shell: bash
         run: tar -xzvf mc-java-ci-build-results.tar.gz
 
-      - name: Run tests
-        shell: bash
-        run: |
-          pwd
-          ls
-          cd tests
-          ./gradlew build --stacktrace
+#      - name: Run tests
+#        shell: bash
+#        run: |
+#          pwd
+#          ls
+#          cd tests
+#          ./gradlew build --stacktrace

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -514,12 +514,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:26 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:30:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -976,12 +976,12 @@ This report was generated on **Fri Nov 05 01:54:26 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:27 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:30:58 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1422,12 +1422,12 @@ This report was generated on **Fri Nov 05 01:54:27 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:30:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -1953,12 +1953,12 @@ This report was generated on **Fri Nov 05 01:54:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:30:59 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2399,12 +2399,12 @@ This report was generated on **Fri Nov 05 01:54:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:31:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2861,12 +2861,12 @@ This report was generated on **Fri Nov 05 01:54:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:31:00 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3291,4 +3291,4 @@ This report was generated on **Fri Nov 05 01:54:31 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Nov 05 01:54:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Nov 05 20:31:01 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.74</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,5 +27,5 @@
 val spineBaseVersion by extra("2.0.0-SNAPSHOT.74")
 val toolBaseVersion by extra("2.0.0-SNAPSHOT.74")
 val mcVersion by extra("2.0.0-SNAPSHOT.74")
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.74")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.75")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This changeset attempts to re-use the CI build result of `Build under Ubuntu` when running the `integration-tests` workflow.

It appends the Ubuntu-based CI build with a step uploading the whole working folder of the repository as a _workflow_ _artifact_. The subsequent `integration-tests` workflow downloads it and unpacks. 

_Note_: to download the artifact conveniently, [a custom action](https://github.com/dawidd6/action-download-artifact) is used.

Restrictions:

- The dependant workflow is only executed according to the `.yml` file which resides in the default branch (`master`) in our case. So any modifications made to `integration-tests.yml` in scope of PRs have no value until they are merged.

- According to the docs, the tests should also be executed from the default (`master`) branch. However, as this PR has not been merged yet, I am not able to verify it.
