### PR TITLE
Use common properties

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.30"
+    const val version      = "1.5.31"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -514,7 +514,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -976,7 +976,7 @@ This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1422,7 +1422,7 @@ This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1953,7 +1953,7 @@ This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2399,7 +2399,7 @@ This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2861,7 +2861,7 @@ This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3291,4 +3291,4 @@ This report was generated on **Wed Nov 10 16:53:31 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 16:53:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 20:34:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -514,7 +514,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -976,7 +976,7 @@ This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:29 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1422,7 +1422,7 @@ This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1953,7 +1953,7 @@ This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2399,7 +2399,7 @@ This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2861,7 +2861,7 @@ This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3291,4 +3291,4 @@ This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 14:27:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 16:53:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -514,12 +514,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:17 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -976,12 +976,12 @@ This report was generated on **Tue Nov 09 19:23:17 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:18 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1422,12 +1422,12 @@ This report was generated on **Tue Nov 09 19:23:18 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:18 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -1953,12 +1953,12 @@ This report was generated on **Tue Nov 09 19:23:18 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:19 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2399,12 +2399,12 @@ This report was generated on **Tue Nov 09 19:23:19 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:19 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2861,12 +2861,12 @@ This report was generated on **Tue Nov 09 19:23:19 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:20 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:34 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3291,4 +3291,4 @@ This report was generated on **Tue Nov 09 19:23:20 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 19:23:20 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 14:27:35 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -141,23 +141,23 @@
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -405,55 +405,55 @@
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -514,7 +514,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:13 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -608,23 +608,23 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -867,55 +867,55 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -976,7 +976,7 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:14 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1062,23 +1062,23 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1313,55 +1313,55 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1422,7 +1422,7 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:14 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1560,23 +1560,23 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1844,55 +1844,55 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -1953,7 +1953,7 @@ This report was generated on **Wed Nov 10 20:34:39 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2039,23 +2039,23 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2290,55 +2290,55 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2399,7 +2399,7 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2493,23 +2493,23 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2752,55 +2752,55 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -2861,7 +2861,7 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:15 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2931,23 +2931,23 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3182,55 +3182,55 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.30.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.5.31.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -3291,4 +3291,4 @@ This report was generated on **Wed Nov 10 20:34:40 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 20:34:41 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Nov 11 14:55:16 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java-annotation/src/main/java/io/spine/tools/mc/java/annotation/gradle/AnnotationAction.java
+++ b/mc-java-annotation/src/main/java/io/spine/tools/mc/java/annotation/gradle/AnnotationAction.java
@@ -29,6 +29,7 @@ package io.spine.tools.mc.java.annotation.gradle;
 import com.google.common.collect.ImmutableSet;
 import io.spine.code.java.ClassName;
 import io.spine.logging.Logging;
+import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.mc.java.annotation.mark.AnnotatorFactory;
 import io.spine.tools.mc.java.annotation.mark.DefaultAnnotatorFactory;
 import io.spine.tools.mc.java.annotation.mark.ModuleAnnotator;
@@ -37,25 +38,25 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.RegularFileProperty;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 import static io.spine.tools.mc.java.annotation.mark.ApiOption.beta;
 import static io.spine.tools.mc.java.annotation.mark.ApiOption.experimental;
 import static io.spine.tools.mc.java.annotation.mark.ApiOption.internal;
 import static io.spine.tools.mc.java.annotation.mark.ApiOption.spi;
 import static io.spine.tools.mc.java.annotation.mark.ModuleAnnotator.translate;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getCodeGenAnnotations;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainGrpcDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainJavaDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedTestGrpcDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedTestJavaDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getInternalClassPatterns;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getInternalMethodNames;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getMainDescriptorSetFile;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getTestDescriptorSetFile;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getCodeGenAnnotations;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainGrpcDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainJavaDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestGrpcDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestJavaDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getInternalClassPatterns;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getInternalMethodNames;
 
 /**
  * A task action which performs generated code annotation.
@@ -116,9 +117,13 @@ final class AnnotationAction implements Action<Task>, Logging {
     }
 
     private File descriptorSetFileOf(Project project) {
-        return mainCode
-               ? getMainDescriptorSetFile(project)
-               : getTestDescriptorSetFile(project);
+        ModelCompilerOptions extension = getModelCompiler(project);
+        RegularFileProperty fileProperty =
+                mainCode
+                ? extension.getMainDescriptorSetFile()
+                : extension.getTestDescriptorSetFile();
+
+        return fileProperty.getAsFile().get();
     }
 
     private String generatedJavaDir(Project project) {

--- a/mc-java-annotation/src/test/java/io/spine/tools/mc/java/annotation/gradle/AnnotatorPluginTest.java
+++ b/mc-java-annotation/src/test/java/io/spine/tools/mc/java/annotation/gradle/AnnotatorPluginTest.java
@@ -301,16 +301,23 @@ class AnnotatorPluginTest {
     }
 
     private static FileDescriptor descriptorOf(FileName testFile) {
-        Path mainDescriptor = DefaultJavaPaths
-                .at(testProjectDir)
-                .buildRoot()
-                .descriptors()
-                .mainDescriptors()
-                .resolve("io.spine.test_" + testProjectDir.getName() + "_3.14" + DESC_EXTENSION);
+        Path mainDescriptor = mainDescriptorPath();
         FileSet fileSet = FileSet.parse(mainDescriptor.toFile());
         Optional<FileDescriptor> file = fileSet.tryFind(testFile);
         checkState(file.isPresent(), "Unable to get file descriptor for `%s`.", testFile);
         FileDescriptor result = file.get();
         return result;
+    }
+
+    /**
+     * Compose the path to the main descriptor set file using the project Maven coordinates
+     * as defined in the test project under {@code resources/annotator-plugin-test}.
+     */
+    private static Path mainDescriptorPath() {
+        return DefaultJavaPaths.at(testProjectDir)
+                .buildRoot()
+                .descriptors()
+                .mainDescriptors()
+                .resolve("io.spine.test_" + testProjectDir.getName() + "_3.14" + DESC_EXTENSION);
     }
 }

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/DirsToClean.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/DirsToClean.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.mc.java.gradle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
+import io.spine.tools.java.fs.DefaultJavaPaths;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.gradle.api.Project;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.spine.tools.mc.java.gradle.McJavaOptions.def;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
+import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Calculates directories to be cleaned for a given project.
+ */
+public class DirsToClean {
+
+    private static final FluentLogger log = FluentLogger.forEnclosingClass();
+
+    /** Prevents instantiation of this utility class. */
+    private DirsToClean() {
+    }
+
+    /**
+     * Obtains directories to be cleaned in the given project.
+     */
+    public static List<File> getFor(Project project) {
+        ImmutableList.Builder<File> result = ImmutableList.builder();
+        result.addAll(tempArtifactDirsOf(project));
+        List<File> dirs = fromOptionsOf(project);
+        if (!dirs.isEmpty()) {
+            log.atFine()
+               .log("Found %d directories to clean: `%s`.", dirs.size(), dirs);
+            result.addAll(dirs);
+        } else {
+            String defaultValue = def(project).generated().toString();
+            log.atFine()
+               .log("Default directory to clean: `%s`.", defaultValue);
+            result.add(new File(defaultValue));
+        }
+        return result.build();
+    }
+
+    private static List<File> fromOptionsOf(Project project) {
+        McJavaOptions options = getMcJavaOptions(project);
+        List<File> dirs = options.dirsToClean
+                    .stream()
+                    .map(File::new)
+                    .collect(toList());
+        return dirs;
+    }
+
+    private static List<File> tempArtifactDirsOf(Project project) {
+        List<File> result = new ArrayList<>();
+        @Nullable File tempArtifactDir = tempArtifactsDirOf(project);
+        @Nullable File tempArtifactDirOfRoot = tempArtifactsDirOf(project.getRootProject());
+        if (tempArtifactDir != null) {
+            result.add(tempArtifactDir);
+            if (tempArtifactDirOfRoot != null
+                    && !tempArtifactDir.equals(tempArtifactDirOfRoot)) {
+                result.add(tempArtifactDirOfRoot);
+            }
+        }
+        return result;
+    }
+
+    private static @Nullable File tempArtifactsDirOf(Project project) {
+        File projectDir = canonicalDirOf(project);
+        File tempArtifactsDir =
+                DefaultJavaPaths.at(projectDir)
+                                .tempArtifacts();
+        if (tempArtifactsDir.exists()) {
+            return tempArtifactsDir;
+        } else {
+            return null;
+        }
+    }
+
+    private static File canonicalDirOf(Project project) {
+        File result;
+        File projectDir = project.getProjectDir();
+        try {
+            result = projectDir.getCanonicalFile();
+        } catch (IOException e) {
+            throw newIllegalStateException(
+                    e, "Unable to obtain canonical project directory `%s`.", projectDir
+            );
+        }
+        return result;
+    }
+}

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newLinkedList;
+import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -199,7 +200,7 @@ public class McJavaOptions {
     @SuppressWarnings("FloggerSplitLogStatement")
 
     public static String getMainProtoDir(Project project) {
-        McJavaOptions extension = extension(project);
+        McJavaOptions extension = getMcJavaOptions(project);
         _debug().log("Extension is `%s`.", extension);
         String protoDir = extension.mainProtoDir;
         _debug().log("`modelCompiler.mainProtoSrcDir` is `%s`.", protoDir);
@@ -209,55 +210,55 @@ public class McJavaOptions {
     }
 
     public static String getTestProtoDir(Project project) {
-        return pathOrDefault(extension(project).testProtoDir,
+        return pathOrDefault(getMcJavaOptions(project).testProtoDir,
                              def(project).src()
                                          .testProto());
     }
 
     public static String getGeneratedMainJavaDir(Project project) {
-        return pathOrDefault(extension(project).generatedMainDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedMainDir,
                              def(project).generated()
                                          .mainJava());
     }
 
     public static String getGeneratedMainGrpcDir(Project project) {
-        return pathOrDefault(extension(project).generatedMainGrpcDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedMainGrpcDir,
                              def(project).generated()
                                          .mainGrpc());
     }
 
     public static String getGeneratedMainResourcesDir(Project project) {
-        return pathOrDefault(extension(project).generatedMainResourcesDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedMainResourcesDir,
                              def(project).generated()
                                          .mainResources());
     }
 
     public static String getGeneratedTestJavaDir(Project project) {
-        return pathOrDefault(extension(project).generatedTestDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedTestDir,
                              def(project).generated()
                                          .testJava());
     }
 
     public static String getGeneratedTestResourcesDir(Project project) {
-        return pathOrDefault(extension(project).generatedTestResourcesDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedTestResourcesDir,
                              def(project).generated()
                                          .testResources());
     }
 
     public static String getGeneratedTestGrpcDir(Project project) {
-        return pathOrDefault(extension(project).generatedTestGrpcDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedTestGrpcDir,
                              def(project).generated()
                                          .testGrpc());
     }
 
     public static String getGeneratedMainRejectionsDir(Project project) {
-        return pathOrDefault(extension(project).generatedMainRejectionsDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedMainRejectionsDir,
                              def(project).generated()
                                          .mainSpine());
     }
 
     public static String getGeneratedTestRejectionsDir(Project project) {
-        return pathOrDefault(extension(project).generatedTestRejectionsDir,
+        return pathOrDefault(getMcJavaOptions(project).generatedTestRejectionsDir,
                              def(project).generated()
                                          .testSpine());
     }
@@ -269,7 +270,7 @@ public class McJavaOptions {
     }
 
     public static Indent getIndent(Project project) {
-        Indent result = extension(project).indent;
+        Indent result = getMcJavaOptions(project).indent;
         _debug().log("The current indent is %d.", result.size());
         return result;
     }
@@ -283,8 +284,9 @@ public class McJavaOptions {
     public static List<String> getDirsToClean(Project project) {
         List<String> dirsToClean = newLinkedList(spineDirs(project));
         _debug().log("Finding the directories to clean.");
-        List<String> dirs = extension(project).dirsToClean;
-        String singleDir = extension(project).dirToClean;
+        McJavaOptions options = getMcJavaOptions(project);
+        List<String> dirs = options.dirsToClean;
+        String singleDir = options.dirToClean;
         if (dirs.size() > 0) {
             _info().log("Found %d directories to clean: `%s`.", dirs.size(), dirs);
             dirsToClean.addAll(dirs);
@@ -311,17 +313,17 @@ public class McJavaOptions {
     }
 
     public static CodeGenAnnotations getCodeGenAnnotations(Project project) {
-        CodeGenAnnotations annotations = extension(project).generateAnnotations;
+        CodeGenAnnotations annotations = getMcJavaOptions(project).generateAnnotations;
         return annotations;
     }
 
     public static ImmutableSet<String> getInternalClassPatterns(Project project) {
-        List<String> patterns = extension(project).internalClassPatterns;
+        List<String> patterns = getMcJavaOptions(project).internalClassPatterns;
         return ImmutableSet.copyOf(patterns);
     }
 
     public static ImmutableSet<String> getInternalMethodNames(Project project) {
-        List<String> patterns = extension(project).internalMethodNames;
+        List<String> patterns = getMcJavaOptions(project).internalMethodNames;
         return ImmutableSet.copyOf(patterns);
     }
 
@@ -360,11 +362,9 @@ public class McJavaOptions {
     /**
      * Obtains the instance of the extension from the given project.
      */
-    public static McJavaOptions extension(Project project) {
-        ModelCompilerOptions mcExtension =
-                project.getExtensions()
-                       .getByType(ModelCompilerOptions.class);
-        ExtensionAware extensionAware = (ExtensionAware) mcExtension;
+    public static McJavaOptions getMcJavaOptions(Project project) {
+        ModelCompilerOptions mcOptions = getModelCompiler(project);
+        ExtensionAware extensionAware = (ExtensionAware) mcOptions;
         McJavaOptions mcJavaExtension =
                 extensionAware.getExtensions()
                               .getByType(McJavaOptions.class);

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
@@ -145,8 +145,12 @@ public class McJavaOptions {
 
     private Project project;
 
-    public static File descriptorSetFileOf(Project project, boolean main) {
-        File result = main
+    /**
+     * Obtains a path of the descriptor set file of the given project for
+     * the specified source set.
+     */
+    public static File descriptorSetFileOf(Project project, boolean mainSourceSet) {
+        File result = mainSourceSet
                       ? getDefaultMainDescriptors(project)
                       : getDefaultTestDescriptors(project);
         return result;

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
@@ -36,11 +36,14 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.spine.tools.gradle.Projects.getDefaultMainDescriptors;
+import static io.spine.tools.gradle.Projects.getDefaultTestDescriptors;
 import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 
 /**
@@ -142,6 +145,13 @@ public class McJavaOptions {
 
     private Project project;
 
+    public static File descriptorSetFileOf(Project project, boolean main) {
+        File result = main
+                      ? getDefaultMainDescriptors(project)
+                      : getDefaultTestDescriptors(project);
+        return result;
+    }
+
     /**
      * Injects the dependency to the given project.
      */
@@ -175,16 +185,6 @@ public class McJavaOptions {
     private static FluentLogger.Api _debug() {
         return logger.atFine();
     }
-
-    @SuppressWarnings({
-            "PMD.MethodNamingConventions",
-            "FloggerSplitLogStatement" // See: https://github.com/SpineEventEngine/base/issues/612
-    })
-    private static FluentLogger.Api _info() {
-        return logger.atInfo();
-    }
-
-    @SuppressWarnings("FloggerSplitLogStatement")
 
     public static String getMainProtoDir(Project project) {
         McJavaOptions extension = getMcJavaOptions(project);

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
@@ -31,7 +31,7 @@ import com.google.common.flogger.FluentLogger;
 import groovy.lang.Closure;
 import io.spine.tools.code.Indent;
 import io.spine.tools.java.fs.DefaultJavaPaths;
-import io.spine.tools.mc.gradle.McExtension;
+import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.mc.java.codegen.JavaCodegenConfig;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
@@ -46,8 +46,6 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newLinkedList;
-import static io.spine.tools.gradle.Projects.getDefaultMainDescriptors;
-import static io.spine.tools.gradle.Projects.getDefaultTestDescriptors;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -59,7 +57,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
         "ClassWithTooManyFields", "PMD.TooManyFields" /* Gradle extensions are flat like this. */,
         "RedundantSuppression" /* "ClassWithTooManyFields" is sometimes not recognized by IDEA. */
 })
-public class McJavaExtension {
+public class McJavaOptions {
 
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
@@ -67,16 +65,6 @@ public class McJavaExtension {
      * The name of the extension, as it appears in a Gradle build script.
      */
     static final String NAME = "java";
-
-    /**
-     * The absolute path to the main Protobuf descriptor set file.
-     */
-    public String mainDescriptorSetFile;
-
-    /**
-     * The absolute path to the test Protobuf descriptor set file.
-     */
-    public String testDescriptorSetFile;
 
     /**
      * The absolute path to the Protobuf source code under the {@code main} directory.
@@ -211,7 +199,7 @@ public class McJavaExtension {
     @SuppressWarnings("FloggerSplitLogStatement")
 
     public static String getMainProtoDir(Project project) {
-        McJavaExtension extension = extension(project);
+        McJavaOptions extension = extension(project);
         _debug().log("Extension is `%s`.", extension);
         String protoDir = extension.mainProtoDir;
         _debug().log("`modelCompiler.mainProtoSrcDir` is `%s`.", protoDir);
@@ -224,22 +212,6 @@ public class McJavaExtension {
         return pathOrDefault(extension(project).testProtoDir,
                              def(project).src()
                                          .testProto());
-    }
-
-    public static File getMainDescriptorSetFile(Project project) {
-        McJavaExtension extension = extension(project);
-        File result = getDefaultMainDescriptors(project);
-        String path = pathOrDefault(extension.mainDescriptorSetFile,
-                                    result);
-        return new File(path);
-    }
-
-    public static File getTestDescriptorSetFile(Project project) {
-        McJavaExtension extension = extension(project);
-        File result = getDefaultTestDescriptors(project);
-        String path = pathOrDefault(extension.testDescriptorSetFile,
-                                    result);
-        return new File(path);
     }
 
     public static String getGeneratedMainJavaDir(Project project) {
@@ -388,14 +360,14 @@ public class McJavaExtension {
     /**
      * Obtains the instance of the extension from the given project.
      */
-    public static McJavaExtension extension(Project project) {
-        McExtension mcExtension =
+    public static McJavaOptions extension(Project project) {
+        ModelCompilerOptions mcExtension =
                 project.getExtensions()
-                       .getByType(McExtension.class);
+                       .getByType(ModelCompilerOptions.class);
         ExtensionAware extensionAware = (ExtensionAware) mcExtension;
-        McJavaExtension mcJavaExtension =
+        McJavaOptions mcJavaExtension =
                 extensionAware.getExtensions()
-                              .getByType(McJavaExtension.class);
+                              .getByType(McJavaOptions.class);
         return mcJavaExtension;
     }
 }

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/McJavaOptions.java
@@ -124,11 +124,9 @@ public class McJavaOptions {
     public Indent indent = Indent.of4();
 
     /**
-     * The absolute paths to directories to delete.
-     *
-     * <p>Either this property OR {@code dirToClean} property is used.
+     * The absolute paths to directories to delete on the {@code preClean} task.
      */
-    public List<String> dirsToClean = new ArrayList<>();
+    public List<String> tempArtifactDirs = new ArrayList<>();
 
     public final CodeGenAnnotations generateAnnotations = new CodeGenAnnotations();
 

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/TempArtifactDirs.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/TempArtifactDirs.java
@@ -45,16 +45,17 @@ import static java.util.stream.Collectors.toList;
 /**
  * Calculates directories to be cleaned for a given project.
  */
-public class DirsToClean {
+public class TempArtifactDirs {
 
     private static final FluentLogger log = FluentLogger.forEnclosingClass();
 
     /** Prevents instantiation of this utility class. */
-    private DirsToClean() {
+    private TempArtifactDirs() {
     }
 
     /**
-     * Obtains directories to be cleaned in the given project.
+     * Obtains directories to be removed in the given project when the {@code preClean} task
+     * is executed.
      */
     public static List<File> getFor(Project project) {
         ImmutableList.Builder<File> result = ImmutableList.builder();
@@ -75,7 +76,7 @@ public class DirsToClean {
 
     private static List<File> fromOptionsOf(Project project) {
         McJavaOptions options = getMcJavaOptions(project);
-        List<File> dirs = options.dirsToClean
+        List<File> dirs = options.tempArtifactDirs
                     .stream()
                     .map(File::new)
                     .collect(toList());

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/package-info.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/package-info.java
@@ -26,7 +26,7 @@
 
 /**
  * This package provides
- * the {@linkplain io.spine.tools.mc.java.gradle.McJavaExtension Gradle project extension}
+ * the {@linkplain io.spine.tools.mc.java.gradle.McJavaOptions Gradle project extension}
  * of Spine Model Compiler for Java ({@code mc-java}) and associated types.
  *
  * <p>The extension is the central place of the configuration of {@code mc-java}.

--- a/mc-java-checks/src/test/java/io/spine/tools/mc/java/checks/gradle/McJavaChecksSeverityTest.java
+++ b/mc-java-checks/src/test/java/io/spine/tools/mc/java/checks/gradle/McJavaChecksSeverityTest.java
@@ -26,7 +26,7 @@
 
 package io.spine.tools.mc.java.checks.gradle;
 
-import io.spine.tools.mc.gradle.McExtension;
+import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.mc.java.checks.gradle.given.ProjectConfigurations;
 import io.spine.tools.mc.java.checks.gradle.given.StubProject;
 import org.gradle.api.Project;
@@ -86,9 +86,9 @@ class McJavaChecksSeverityTest {
         return extension;
     }
 
-    private McExtension configureModelCompilerExtension() {
+    private ModelCompilerOptions configureModelCompilerExtension() {
         ExtensionContainer extensions = project.getExtensions();
-        McExtension extension = extensions.create(McExtension.name, McExtension.class);
+        ModelCompilerOptions extension = extensions.create(ModelCompilerOptions.name, ModelCompilerOptions.class);
         return extension;
     }
 

--- a/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/ProtoModule.java
+++ b/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/ProtoModule.java
@@ -37,8 +37,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.gradle.Projects.sourceSet;
 import static io.spine.tools.gradle.SourceScope.main;
 import static io.spine.tools.gradle.SourceScope.test;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainRejectionsDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedTestRejectionsDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainRejectionsDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestRejectionsDir;
 
 /**
  * A source code module with Protobuf.

--- a/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenAction.java
+++ b/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenAction.java
@@ -64,10 +64,10 @@ import static com.google.common.flogger.LazyArgs.lazy;
 final class RejectionGenAction extends CodeGenerationAction {
 
     RejectionGenAction(Project project,
-                       Supplier<FileSet> files,
+                       Supplier<FileSet> protoFiles,
                        Supplier<String> targetDirPath,
                        Supplier<String> protoSrcDirPath) {
-        super(project, files, targetDirPath, protoSrcDirPath);
+        super(project, protoFiles, targetDirPath, protoSrcDirPath);
     }
 
     @Override

--- a/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenAction.java
+++ b/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenAction.java
@@ -37,7 +37,7 @@ import io.spine.tools.code.Indent;
 import io.spine.tools.gradle.CodeGenerationAction;
 import io.spine.tools.java.code.TypeSpec;
 import io.spine.tools.java.code.TypeSpecWriter;
-import io.spine.tools.mc.java.gradle.McJavaExtension;
+import io.spine.tools.mc.java.gradle.McJavaOptions;
 import io.spine.tools.mc.java.rejection.gen.RThrowableSpec;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -55,11 +55,11 @@ import static com.google.common.flogger.LazyArgs.lazy;
  * rejection type which extends {@link io.spine.base.RejectionThrowable RejectionThrowable} and
  * encloses an instance of the corresponding proto message.
  *
- * <p>The {@link McJavaExtension#generatedMainRejectionsDir} and
- * {@link McJavaExtension#generatedTestRejectionsDir} options allow to customize the target root
+ * <p>The {@link McJavaOptions#generatedMainRejectionsDir} and
+ * {@link McJavaOptions#generatedTestRejectionsDir} options allow to customize the target root
  * directory for code generation.
  *
- * <p>The {@link McJavaExtension#indent} option sets the indentation of the generated source files.
+ * <p>The {@link McJavaOptions#indent} option sets the indentation of the generated source files.
  */
 final class RejectionGenAction extends CodeGenerationAction {
 
@@ -123,6 +123,6 @@ final class RejectionGenAction extends CodeGenerationAction {
 
     @Override
     protected Indent getIndent(Project project) {
-        return McJavaExtension.getIndent(project);
+        return McJavaOptions.getIndent(project);
     }
 }

--- a/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenPlugin.java
+++ b/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenPlugin.java
@@ -37,16 +37,15 @@ import java.util.function.Supplier;
 
 import static io.spine.tools.gradle.JavaTaskName.compileJava;
 import static io.spine.tools.gradle.JavaTaskName.compileTestJava;
+import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainRejectionsDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestRejectionsDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMainProtoDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getTestProtoDir;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.generateRejections;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.generateTestRejections;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeDescriptorSet;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeTestDescriptorSet;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getMainDescriptorSetFile;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getMainProtoDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainRejectionsDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedTestRejectionsDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getTestDescriptorSetFile;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getTestProtoDir;
 
 /**
  * Plugin which generates Rejections declared in {@code rejections.proto} files.
@@ -109,11 +108,17 @@ public class RejectionGenPlugin extends ProtoPlugin {
 
     @Override
     protected Supplier<File> mainDescriptorFile(Project project) {
-        return () -> getMainDescriptorSetFile(project);
+        return () -> getModelCompiler(project)
+                .getMainDescriptorSetFile()
+                .getAsFile()
+                .get();
     }
 
     @Override
     protected Supplier<File> testDescriptorFile(Project project) {
-        return () -> getTestDescriptorSetFile(project);
+        return () -> getModelCompiler(project)
+                .getTestDescriptorSetFile()
+                .getAsFile()
+                .get();
     }
 }

--- a/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenPlugin.java
+++ b/mc-java-rejection/src/main/java/io/spine/tools/mc/java/rejection/gradle/RejectionGenPlugin.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 
 import static io.spine.tools.gradle.JavaTaskName.compileJava;
 import static io.spine.tools.gradle.JavaTaskName.compileTestJava;
-import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.descriptorSetFileOf;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainRejectionsDir;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestRejectionsDir;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getMainProtoDir;
@@ -108,17 +108,11 @@ public class RejectionGenPlugin extends ProtoPlugin {
 
     @Override
     protected Supplier<File> mainDescriptorFile(Project project) {
-        return () -> getModelCompiler(project)
-                .getMainDescriptorSetFile()
-                .getAsFile()
-                .get();
+        return () -> descriptorSetFileOf(project, true);
     }
 
     @Override
     protected Supplier<File> testDescriptorFile(Project project) {
-        return () -> getModelCompiler(project)
-                .getTestDescriptorSetFile()
-                .getAsFile()
-                .get();
+        return () -> descriptorSetFileOf(project, false);
     }
 }

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
@@ -28,12 +28,12 @@ package io.spine.tools.mc.java.gradle.plugins;
 import com.google.common.flogger.FluentLogger;
 import io.spine.tools.gradle.GradleTask;
 import io.spine.tools.gradle.SpinePlugin;
-import io.spine.tools.mc.java.gradle.McJavaOptions;
+import io.spine.tools.mc.java.gradle.DirsToClean;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
-import java.nio.file.Paths;
+import java.io.File;
 import java.util.List;
 
 import static com.google.common.flogger.LazyArgs.lazy;
@@ -60,12 +60,12 @@ public class CleaningPlugin extends SpinePlugin {
 
     private void cleanIn(Project project) {
         FluentLogger.Api debug = _debug();
-        List<String> dirsToClean = McJavaOptions.getDirsToClean(project);
+        List<File> dirsToClean = DirsToClean.getFor(project);
         debug.log(
                 "Pre-clean: deleting the directories (`%s`).", lazy(dirsToClean::toString)
         );
         dirsToClean.stream()
-                   .map(Paths::get)
+                   .map(File::toPath)
                    .forEach(dir -> {
                        debug.log("Deleting directory `%s`...", dir);
                        deleteRecursively(dir);

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
@@ -28,15 +28,13 @@ package io.spine.tools.mc.java.gradle.plugins;
 import com.google.common.flogger.FluentLogger;
 import io.spine.tools.gradle.GradleTask;
 import io.spine.tools.gradle.SpinePlugin;
-import io.spine.tools.mc.java.gradle.McJavaExtension;
+import io.spine.tools.mc.java.gradle.McJavaOptions;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
-import java.io.File;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.google.common.flogger.LazyArgs.lazy;
 import static io.spine.io.Delete.deleteRecursively;
@@ -62,7 +60,7 @@ public class CleaningPlugin extends SpinePlugin {
 
     private void cleanIn(Project project) {
         FluentLogger.Api debug = _debug();
-        List<String> dirsToClean = McJavaExtension.getDirsToClean(project);
+        List<String> dirsToClean = McJavaOptions.getDirsToClean(project);
         debug.log(
                 "Pre-clean: deleting the directories (`%s`).", lazy(dirsToClean::toString)
         );

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
@@ -28,7 +28,7 @@ package io.spine.tools.mc.java.gradle.plugins;
 import com.google.common.flogger.FluentLogger;
 import io.spine.tools.gradle.GradleTask;
 import io.spine.tools.gradle.SpinePlugin;
-import io.spine.tools.mc.java.gradle.DirsToClean;
+import io.spine.tools.mc.java.gradle.TempArtifactDirs;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -60,7 +60,7 @@ public class CleaningPlugin extends SpinePlugin {
 
     private void cleanIn(Project project) {
         FluentLogger.Api debug = _debug();
-        List<File> dirsToClean = DirsToClean.getFor(project);
+        List<File> dirsToClean = TempArtifactDirs.getFor(project);
         debug.log(
                 "Pre-clean: deleting the directories (`%s`).", lazy(dirsToClean::toString)
         );

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/DescriptorSetMergerPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/DescriptorSetMergerPlugin.java
@@ -30,12 +30,14 @@ import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.GradleTask;
 import io.spine.tools.gradle.SpinePlugin;
 import io.spine.tools.gradle.TaskName;
+import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.type.FileDescriptorSuperset;
 import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.RegularFileProperty;
 
 import java.io.File;
 
@@ -43,12 +45,11 @@ import static io.spine.tools.gradle.ConfigurationName.runtimeClasspath;
 import static io.spine.tools.gradle.ConfigurationName.testRuntimeClasspath;
 import static io.spine.tools.gradle.JavaTaskName.processResources;
 import static io.spine.tools.gradle.JavaTaskName.processTestResources;
-import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeDescriptorSet;
-import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeTestDescriptorSet;
 import static io.spine.tools.gradle.ProtobufTaskName.generateProto;
 import static io.spine.tools.gradle.ProtobufTaskName.generateTestProto;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getMainDescriptorSetFile;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getTestDescriptorSetFile;
+import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
+import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeDescriptorSet;
+import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeTestDescriptorSet;
 
 /**
  * A Gradle plugin which merges the descriptor file with all the descriptor files from
@@ -120,9 +121,11 @@ public class DescriptorSetMergerPlugin extends SpinePlugin {
     }
 
     private static File descriptorSet(Project project, boolean tests) {
-        File descriptor = tests
-                          ? getTestDescriptorSetFile(project)
-                          : getMainDescriptorSetFile(project);
+        ModelCompilerOptions extension = getModelCompiler(project);
+        RegularFileProperty fileProperty = tests
+                ? extension.getTestDescriptorSetFile()
+                : extension.getMainDescriptorSetFile();
+        File descriptor = fileProperty.getAsFile().get();
         return descriptor;
     }
 }

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/DescriptorSetMergerPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/DescriptorSetMergerPlugin.java
@@ -30,14 +30,12 @@ import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.GradleTask;
 import io.spine.tools.gradle.SpinePlugin;
 import io.spine.tools.gradle.TaskName;
-import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.type.FileDescriptorSuperset;
 import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.file.RegularFileProperty;
 
 import java.io.File;
 
@@ -47,7 +45,7 @@ import static io.spine.tools.gradle.JavaTaskName.processResources;
 import static io.spine.tools.gradle.JavaTaskName.processTestResources;
 import static io.spine.tools.gradle.ProtobufTaskName.generateProto;
 import static io.spine.tools.gradle.ProtobufTaskName.generateTestProto;
-import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.descriptorSetFileOf;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeDescriptorSet;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.mergeTestDescriptorSet;
 
@@ -80,7 +78,7 @@ public class DescriptorSetMergerPlugin extends SpinePlugin {
         return task -> {
             Project project = task.getProject();
             Configuration configuration = configuration(project, configurationName(tests));
-            File descriptorSet = descriptorSet(project, tests);
+            File descriptorSet = descriptorSetFileOf(project, !tests);
             FileDescriptorSuperset superset = new FileDescriptorSuperset();
             configuration.forEach(superset::addFromDependency);
             if (descriptorSet.exists()) {
@@ -120,12 +118,4 @@ public class DescriptorSetMergerPlugin extends SpinePlugin {
                : processResources;
     }
 
-    private static File descriptorSet(Project project, boolean tests) {
-        ModelCompilerOptions extension = getModelCompiler(project);
-        RegularFileProperty fileProperty = tests
-                ? extension.getTestDescriptorSetFile()
-                : extension.getMainDescriptorSetFile();
-        File descriptor = fileProperty.getAsFile().get();
-        return descriptor;
-    }
 }

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
@@ -63,6 +63,7 @@ import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 import static io.spine.tools.mc.java.gradle.Artifacts.SPINE_PROTOC_PLUGIN_NAME;
 import static io.spine.tools.mc.java.gradle.Artifacts.gRpcProtocPlugin;
 import static io.spine.tools.mc.java.gradle.Artifacts.spineProtocPlugin;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.writeDescriptorReference;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.writePluginConfiguration;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.writeTestDescriptorReference;
@@ -171,8 +172,8 @@ public final class JavaProtocConfigurationPlugin extends ProtocConfigurationPlug
 
     private static void writePluginConfig(Task protocTask, Path configPath) {
         Project project = protocTask.getProject();
-        McJavaOptions extension = McJavaOptions.extension(project);
-        SpineProtocConfig config = extension.codegen.toProto();
+        McJavaOptions options = getMcJavaOptions(project);
+        SpineProtocConfig config = options.codegen.toProto();
 
         ensureFile(configPath);
         try (FileOutputStream fos = new FileOutputStream(configPath.toFile())) {

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
@@ -36,7 +36,8 @@ import io.spine.tools.gradle.SourceScope;
 import io.spine.tools.gradle.TaskName;
 import io.spine.tools.java.fs.DefaultJavaPaths;
 import io.spine.tools.java.fs.GeneratedRoot;
-import io.spine.tools.mc.java.gradle.McJavaExtension;
+import io.spine.tools.mc.gradle.ModelCompilerOptions;
+import io.spine.tools.mc.java.gradle.McJavaOptions;
 import io.spine.tools.protoc.SpineProtocConfig;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
@@ -58,6 +59,7 @@ import static io.spine.tools.gradle.Projects.sourceSet;
 import static io.spine.tools.gradle.ProtocPluginName.grpc;
 import static io.spine.tools.gradle.ProtocPluginName.spineProtoc;
 import static io.spine.tools.java.fs.DefaultJavaPaths.at;
+import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 import static io.spine.tools.mc.java.gradle.Artifacts.SPINE_PROTOC_PLUGIN_NAME;
 import static io.spine.tools.mc.java.gradle.Artifacts.gRpcProtocPlugin;
 import static io.spine.tools.mc.java.gradle.Artifacts.spineProtocPlugin;
@@ -134,8 +136,17 @@ public final class JavaProtocConfigurationPlugin extends ProtocConfigurationPlug
     }
 
     @Override
+    protected File getMainDescriptorSet(Project project) {
+        ModelCompilerOptions options = getModelCompiler(project);
+        File result = options.getMainDescriptorSetFile().getAsFile().get();
+        return result;
+    }
+
+    @Override
     protected File getTestDescriptorSet(Project project) {
-        return McJavaExtension.getTestDescriptorSetFile(project);
+        ModelCompilerOptions options = getModelCompiler(project);
+        File result = options.getTestDescriptorSetFile().getAsFile().get();
+        return result;
     }
 
     @Override
@@ -143,11 +154,6 @@ public final class JavaProtocConfigurationPlugin extends ProtocConfigurationPlug
         DefaultJavaPaths javaProject = at(project.getProjectDir());
         GeneratedRoot result = javaProject.generated();
         return result.path();
-    }
-
-    @Override
-    protected File getMainDescriptorSet(Project project) {
-        return McJavaExtension.getMainDescriptorSetFile(project);
     }
 
     /**
@@ -165,7 +171,7 @@ public final class JavaProtocConfigurationPlugin extends ProtocConfigurationPlug
 
     private static void writePluginConfig(Task protocTask, Path configPath) {
         Project project = protocTask.getProject();
-        McJavaExtension extension = McJavaExtension.extension(project);
+        McJavaOptions extension = McJavaOptions.extension(project);
         SpineProtocConfig config = extension.codegen.toProto();
 
         ensureFile(configPath);

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/JavaProtocConfigurationPlugin.java
@@ -36,7 +36,6 @@ import io.spine.tools.gradle.SourceScope;
 import io.spine.tools.gradle.TaskName;
 import io.spine.tools.java.fs.DefaultJavaPaths;
 import io.spine.tools.java.fs.GeneratedRoot;
-import io.spine.tools.mc.gradle.ModelCompilerOptions;
 import io.spine.tools.mc.java.gradle.McJavaOptions;
 import io.spine.tools.protoc.SpineProtocConfig;
 import org.gradle.api.NamedDomainObjectContainer;
@@ -59,10 +58,10 @@ import static io.spine.tools.gradle.Projects.sourceSet;
 import static io.spine.tools.gradle.ProtocPluginName.grpc;
 import static io.spine.tools.gradle.ProtocPluginName.spineProtoc;
 import static io.spine.tools.java.fs.DefaultJavaPaths.at;
-import static io.spine.tools.mc.gradle.ModelCompilerOptionsKt.getModelCompiler;
 import static io.spine.tools.mc.java.gradle.Artifacts.SPINE_PROTOC_PLUGIN_NAME;
 import static io.spine.tools.mc.java.gradle.Artifacts.gRpcProtocPlugin;
 import static io.spine.tools.mc.java.gradle.Artifacts.spineProtocPlugin;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.descriptorSetFileOf;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.writeDescriptorReference;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.writePluginConfiguration;
@@ -138,15 +137,13 @@ public final class JavaProtocConfigurationPlugin extends ProtocConfigurationPlug
 
     @Override
     protected File getMainDescriptorSet(Project project) {
-        ModelCompilerOptions options = getModelCompiler(project);
-        File result = options.getMainDescriptorSetFile().getAsFile().get();
+        File result = descriptorSetFileOf(project, true);
         return result;
     }
 
     @Override
     protected File getTestDescriptorSet(Project project) {
-        ModelCompilerOptions options = getModelCompiler(project);
-        File result = options.getTestDescriptorSetFile().getAsFile().get();
+        File result = descriptorSetFileOf(project, false);
         return result;
     }
 

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/McJavaPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/McJavaPlugin.java
@@ -35,6 +35,8 @@ import org.gradle.api.Project;
 
 import java.util.stream.Stream;
 import io.spine.tools.mc.gradle.LanguagePlugin;
+
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
 import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
@@ -51,7 +53,7 @@ public class McJavaPlugin extends LanguagePlugin implements Logging {
     @Override
     public void apply(Project project) {
         super.apply(project);
-        McJavaOptions extension = McJavaOptions.extension(project);
+        McJavaOptions extension = getMcJavaOptions(project);
         extension.injectProject(project);
         createAndApplyPluginsIn(project);
     }

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/McJavaPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/McJavaPlugin.java
@@ -28,7 +28,7 @@ package io.spine.tools.mc.java.gradle.plugins;
 import io.spine.logging.Logging;
 import io.spine.tools.mc.java.annotation.gradle.AnnotatorPlugin;
 import io.spine.tools.mc.java.checks.gradle.McJavaChecksPlugin;
-import io.spine.tools.mc.java.gradle.McJavaExtension;
+import io.spine.tools.mc.java.gradle.McJavaOptions;
 import io.spine.tools.mc.java.rejection.gradle.RejectionGenPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -45,13 +45,13 @@ import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 public class McJavaPlugin extends LanguagePlugin implements Logging {
 
     public McJavaPlugin() {
-        super(McJavaExtension.name(), getKotlinClass(McJavaExtension.class));
+        super(McJavaOptions.name(), getKotlinClass(McJavaOptions.class));
     }
 
     @Override
     public void apply(Project project) {
         super.apply(project);
-        McJavaExtension extension = McJavaExtension.extension(project);
+        McJavaOptions extension = McJavaOptions.extension(project);
         extension.injectProject(project);
         createAndApplyPluginsIn(project);
     }

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/DirsToCleanTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/DirsToCleanTest.java
@@ -48,8 +48,8 @@ import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.newUuid;
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("`McJavaExtension` directories to clean should")
-class McJavaOptionsDirsTest {
+@DisplayName("`DirsToClean` should")
+class DirsToCleanTest {
 
     private Project project = null;
     private File projectDir = null;
@@ -57,7 +57,7 @@ class McJavaOptionsDirsTest {
 
     @BeforeEach
     void setUp() {
-        projectDir = TempDir.forClass(McJavaOptionsDirsTest.class);
+        projectDir = TempDir.forClass(DirsToCleanTest.class);
         project = StubProject.createAt(projectDir);
         RepositoryHandler repositories = project.getRepositories();
         applyStandard(repositories);

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsDirsTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsDirsTest.java
@@ -47,21 +47,21 @@ import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.newUuid;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`McJavaExtension` directories to clean should")
-class McJavaExtensionDirsTest {
+class McJavaOptionsDirsTest {
 
     private Project project = null;
     private File projectDir = null;
-    private McJavaExtension extension = null;
+    private McJavaOptions extension = null;
 
     @BeforeEach
     void setUp() {
-        projectDir = TempDir.forClass(McJavaExtensionDirsTest.class);
+        projectDir = TempDir.forClass(McJavaOptionsDirsTest.class);
         project = StubProject.createAt(projectDir);
         RepositoryHandler repositories = project.getRepositories();
         applyStandard(repositories);
         project.getPluginManager()
                .apply(MC_JAVA_GRADLE_PLUGIN_ID);
-        extension = McJavaExtension.extension(project);
+        extension = McJavaOptions.extension(project);
     }
 
     @Nested
@@ -144,7 +144,7 @@ class McJavaExtensionDirsTest {
         }
 
         private List<String> actualDirs() {
-            return McJavaExtension.getDirsToClean(project);
+            return McJavaOptions.getDirsToClean(project);
         }
     }
 }

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsDirsTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsDirsTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.tools.mc.java.StandardRepos.applyStandard;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.MC_JAVA_GRADLE_PLUGIN_ID;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.newUuid;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -61,7 +62,7 @@ class McJavaOptionsDirsTest {
         applyStandard(repositories);
         project.getPluginManager()
                .apply(MC_JAVA_GRADLE_PLUGIN_ID);
-        extension = McJavaOptions.extension(project);
+        extension = getMcJavaOptions(project);
     }
 
     @Nested

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsTest.java
@@ -38,24 +38,22 @@ import java.io.File;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.tools.mc.java.StandardRepos.applyStandard;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainRejectionsDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedMainResourcesDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getGeneratedTestResourcesDir;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getMainDescriptorSetFile;
-import static io.spine.tools.mc.java.gradle.McJavaExtension.getTestDescriptorSetFile;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainRejectionsDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainResourcesDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestResourcesDir;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.MC_JAVA_GRADLE_PLUGIN_ID;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.newUuid;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @DisplayName("`McJavaExtension` should")
-class McJavaExtensionTest {
+class McJavaOptionsTest {
 
     private static Project project = null;
-    private static McJavaExtension extension = null;
+    private static McJavaOptions extension = null;
 
     @BeforeAll
     static void setUp() {
-        File projectDir = TempDir.forClass(McJavaExtensionTest.class);
+        File projectDir = TempDir.forClass(McJavaOptionsTest.class);
         project = StubProject.createAt(projectDir);
         RepositoryHandler repositories = project.getRepositories();
         applyStandard(repositories);
@@ -63,7 +61,7 @@ class McJavaExtensionTest {
         repositories.mavenCentral();
         project.getPluginManager()
                .apply(MC_JAVA_GRADLE_PLUGIN_ID);
-        extension = McJavaExtension.extension(project);
+        extension = McJavaOptions.extension(project);
     }
 
     @Nested
@@ -111,54 +109,6 @@ class McJavaExtensionTest {
 
             assertThat(dir)
                     .isEqualTo(extension.generatedTestResourcesDir);
-        }
-    }
-
-    @Nested
-    @DisplayName("for `mainDescriptorSetPath` return")
-    class MainDescriptorSetPath {
-
-        @Test
-        @DisplayName("default value, if not set")
-        void defaultValue() {
-            File file = getMainDescriptorSetFile(project);
-
-            assertNotEmptyAndIsInProjectDir(file.toString());
-        }
-
-        @Test
-        @DisplayName("specified value, if set")
-        void specifiedValue() {
-            extension.mainDescriptorSetFile = newUuid();
-
-            File file = getMainDescriptorSetFile(project);
-
-            assertThat(file.toString())
-                    .isEqualTo(extension.mainDescriptorSetFile);
-        }
-    }
-
-    @Nested
-    @DisplayName("for `testDescriptorSetPath` return")
-    class TestDescriptorSetPath {
-
-        @Test
-        @DisplayName("default value, if not set")
-        void defaultValue() {
-            File file = getTestDescriptorSetFile(project);
-
-            assertNotEmptyAndIsInProjectDir(file.toString());
-        }
-
-        @Test
-        @DisplayName("specified value, if set")
-        void specifiedValue() {
-            extension.testDescriptorSetFile = newUuid();
-
-            File file = getTestDescriptorSetFile(project);
-
-            assertThat(file.toString())
-                    .isEqualTo(extension.testDescriptorSetFile);
         }
     }
 

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/McJavaOptionsTest.java
@@ -41,6 +41,7 @@ import static io.spine.tools.mc.java.StandardRepos.applyStandard;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainRejectionsDir;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedMainResourcesDir;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.getGeneratedTestResourcesDir;
+import static io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.MC_JAVA_GRADLE_PLUGIN_ID;
 import static io.spine.tools.mc.java.gradle.given.ModelCompilerTestEnv.newUuid;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -61,7 +62,7 @@ class McJavaOptionsTest {
         repositories.mavenCentral();
         project.getPluginManager()
                .apply(MC_JAVA_GRADLE_PLUGIN_ID);
-        extension = McJavaOptions.extension(project);
+        extension = getMcJavaOptions(project);
     }
 
     @Nested

--- a/mc-java/src/test/java/io/spine/tools/mc/java/gradle/TempArtifactDirsTest.java
+++ b/mc-java/src/test/java/io/spine/tools/mc/java/gradle/TempArtifactDirsTest.java
@@ -49,7 +49,7 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`DirsToClean` should")
-class DirsToCleanTest {
+class TempArtifactDirsTest {
 
     private Project project = null;
     private File projectDir = null;
@@ -57,7 +57,7 @@ class DirsToCleanTest {
 
     @BeforeEach
     void setUp() {
-        projectDir = TempDir.forClass(DirsToCleanTest.class);
+        projectDir = TempDir.forClass(TempArtifactDirsTest.class);
         project = StubProject.createAt(projectDir);
         RepositoryHandler repositories = project.getRepositories();
         applyStandard(repositories);
@@ -90,11 +90,11 @@ class DirsToCleanTest {
         @Test
         @DisplayName("list, if array is set")
         void list() {
-            options.dirsToClean = newArrayList(newUuid(), newUuid());
+            options.tempArtifactDirs = newArrayList(newUuid(), newUuid());
 
             List<String> actualDirs = actualDirs();
             assertThat(actualDirs)
-                    .isEqualTo(options.dirsToClean);
+                    .isEqualTo(options.tempArtifactDirs);
         }
     }
 
@@ -118,10 +118,10 @@ class DirsToCleanTest {
 
     private List<String> actualDirs() {
         List<String> result =
-                DirsToClean.getFor(project)
-                           .stream()
-                           .map(File::toString)
-                           .collect(toList());
+                TempArtifactDirs.getFor(project)
+                                .stream()
+                                .map(File::toString)
+                                .collect(toList());
         return result;
     }
 }

--- a/mc-java/src/test/kotlin/io/spine/tools/mc/java/codegen/CodegenTest.kt
+++ b/mc-java/src/test/kotlin/io/spine/tools/mc/java/codegen/CodegenTest.kt
@@ -41,6 +41,7 @@ import io.spine.query.EntityStateField
 import io.spine.tools.java.code.UuidMethodFactory
 import io.spine.tools.mc.java.applyStandard
 import io.spine.tools.mc.java.gradle.McJavaOptions
+import io.spine.tools.mc.java.gradle.McJavaOptions.getMcJavaOptions
 import io.spine.tools.mc.java.gradle.plugins.McJavaPlugin
 import io.spine.tools.proto.code.ProtoTypeName
 import io.spine.tools.protoc.GenerateFields
@@ -66,7 +67,7 @@ class `'codegen { }' block should` {
             it.plugin("java")
             it.plugin(McJavaPlugin::class.java)
         }
-        extension = McJavaOptions.extension(project)
+        extension = getMcJavaOptions(project)
     }
 
     @Test

--- a/mc-java/src/test/kotlin/io/spine/tools/mc/java/codegen/CodegenTest.kt
+++ b/mc-java/src/test/kotlin/io/spine/tools/mc/java/codegen/CodegenTest.kt
@@ -40,7 +40,7 @@ import io.spine.option.OptionsProto
 import io.spine.query.EntityStateField
 import io.spine.tools.java.code.UuidMethodFactory
 import io.spine.tools.mc.java.applyStandard
-import io.spine.tools.mc.java.gradle.McJavaExtension
+import io.spine.tools.mc.java.gradle.McJavaOptions
 import io.spine.tools.mc.java.gradle.plugins.McJavaPlugin
 import io.spine.tools.proto.code.ProtoTypeName
 import io.spine.tools.protoc.GenerateFields
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Test
 
 class `'codegen { }' block should` {
 
-    private lateinit var extension: McJavaExtension
+    private lateinit var extension: McJavaOptions
 
     @BeforeEach
     fun prepareExtension() {
@@ -66,7 +66,7 @@ class `'codegen { }' block should` {
             it.plugin("java")
             it.plugin(McJavaPlugin::class.java)
         }
-        extension = McJavaExtension.extension(project)
+        extension = McJavaOptions.extension(project)
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.75</version>
+<version>2.0.0-SNAPSHOT.76</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -50,7 +50,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-model-compiler</artifactId>
-    <version>2.0.0-SNAPSHOT.75</version>
+    <version>2.0.0-SNAPSHOT.77</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-stdlib-jdk8</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -235,17 +235,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-compiler-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-    <version>1.5.30</version>
+    <version>1.5.31</version>
   </dependency>
 </dependencies>
 

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.5.30"
+    const val version      = "1.5.31"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/tests/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -26,7 +26,7 @@
 
 val spineBaseVersion by extra("2.0.0-SNAPSHOT.74")
 val toolBaseVersion by extra("2.0.0-SNAPSHOT.74")
-val mcVersion by extra("2.0.0-SNAPSHOT.76")
+val mcVersion by extra("2.0.0-SNAPSHOT.77")
 
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.75")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.76")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This PR:
  * Renames `McExtension` to `McJavaOptions`
  * Eliminates the `dirToClean` option in favor of using only  the option called now `tempArtifactDirs`.
  * Extracts calculation of temporary artifact directories into the utility class `TempArtifactDirs`. 
     Presumably, the class would be converted into Kotlin extensions of `Project` in one of the following PRs.
  * Eliminates usage of `mainDescriptorSetFile` and `testDescriptorSetFile` (and corresponding methods of `McJavaOptions`) in favor of using default calculated values for these files.

