### PR TITLE
Ignore ClassCanBeStatic errors from Lift

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,1 @@
+ignoreRules = [ "ClassCanBeStatic" ]


### PR DESCRIPTION
Some PRs, such as #18, have lots of ClassCanBeStatic errors (from ErrorProne) which are ignored. If these are uninteresting they can be ignored via CI configuration.