### PR TITLE
Skip validation Gradle configuration when turned off

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -608,7 +608,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:30 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1172,7 +1172,7 @@ This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:31 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1720,7 +1720,7 @@ This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:32 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2342,7 +2342,7 @@ This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:32 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2890,7 +2890,7 @@ This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3454,7 +3454,7 @@ This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:34 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3985,4 +3985,4 @@ This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Feb 15 18:11:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 16 12:32:34 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -608,12 +608,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:52 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1172,12 +1172,12 @@ This report was generated on **Fri Feb 04 16:42:52 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:17 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1720,12 +1720,12 @@ This report was generated on **Fri Feb 04 16:42:53 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:53 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 2.8.8.
@@ -2342,12 +2342,12 @@ This report was generated on **Fri Feb 04 16:42:53 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:18 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2890,12 +2890,12 @@ This report was generated on **Fri Feb 04 16:42:54 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3454,12 +3454,12 @@ This report was generated on **Fri Feb 04 16:42:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:55 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:19 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -3985,4 +3985,4 @@ This report was generated on **Fri Feb 04 16:42:55 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 04 16:42:56 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Feb 15 18:11:20 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/codegen/CodegenOptionsConfig.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/codegen/CodegenOptionsConfig.java
@@ -70,9 +70,13 @@ public final class CodegenOptionsConfig extends Config<CodegenOptions> {
     private final SignalConfig rejections;
     private final EntityConfig entities;
     private final UuidConfig uuids;
-    private final ValidationConfig validation;
     private final Set<Messages> messagesConfigs = new HashSet<>();
     private final Project project;
+
+    /**
+     * Configuration for generating validation code
+     */
+    public final ValidationConfig validation;
 
     @Internal
     public CodegenOptionsConfig(Project project) {
@@ -208,9 +212,7 @@ public final class CodegenOptionsConfig extends Config<CodegenOptions> {
 
     private Classpath buildClasspath() {
         var classpath = Classpath.newBuilder();
-        Collection<JavaCompile> javaCompileViews =
-                project.getTasks()
-                        .withType(JavaCompile.class);
+        Collection<JavaCompile> javaCompileViews = project.getTasks().withType(JavaCompile.class);
         ImmutableList.copyOf(javaCompileViews)
                      .stream()
                      .map(JavaCompile::getClasspath)

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/codegen/ValidationConfig.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/codegen/ValidationConfig.java
@@ -81,6 +81,13 @@ public final class ValidationConfig extends Config<Validation> {
         skipValidatingBuilders.set(false);
     }
 
+    /**
+     * Checks if the validation code should be generated.
+     */
+    public boolean shouldSkipValidation() {
+        return skipValidation.get();
+    }
+
     @Override
     Validation toProto() {
         return Validation.newBuilder()

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.Project;
 
 import static io.spine.tools.mc.java.gradle.Artifacts.validationJava;
 import static io.spine.tools.mc.java.gradle.Artifacts.validationRuntime;
+import static io.spine.tools.mc.java.gradle.Projects.getMcJava;
 import static java.io.File.separatorChar;
 import static java.lang.String.format;
 
@@ -54,6 +55,11 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
     public void apply(Project target) {
         target.getPluginManager()
               .apply(PROTO_DATA_ID);
+        var options = getMcJava(target).codegen.toProto();
+        var validation = options.getValidation();
+        if (validation.getSkipValidation()) {
+            return;
+        }
         var ext = target.getExtensions()
                         .getByType(Extension.class);
         ext.renderers(

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -53,8 +53,11 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project target) {
-        target.getPluginManager()
-              .apply(PROTO_DATA_ID);
+        target.afterEvaluate(ProtoDataConfigPlugin::configureProtoData);
+        target.getPluginManager().apply(PROTO_DATA_ID);
+    }
+
+    private static void configureProtoData(Project target) {
         var options = getMcJava(target).codegen.validation;
         if (options.shouldSkipValidation()) {
             return;

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -55,11 +55,11 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
     public void apply(Project target) {
         target.getPluginManager()
               .apply(PROTO_DATA_ID);
-        var options = getMcJava(target).codegen.toProto();
-        var validation = options.getValidation();
-        if (validation.getSkipValidation()) {
+        var options = getMcJava(target).codegen.validation;
+        if (options.shouldSkipValidation()) {
             return;
         }
+
         var ext = target.getExtensions()
                         .getByType(Extension.class);
         ext.renderers(

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -50,7 +50,17 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
     private static final String PROTO_DATA_ID = "io.spine.proto-data";
     private static final String CONFIG_SUBDIR = "protodata-config";
 
-
+    /**
+     * Applies the {@code io.spine.proto-data} plugin to the project and, if the user needs
+     * validation code generation, configures ProtoData to generate Java validation code.
+     *
+     * <p>ProtoData configuration is a tricky operation because of Gradle's lifecycle. On one hand,
+     * to check if the user disables validation via {@link io.spine.tools.mc.java.gradle.codegen.ValidationConfig#skipValidation()},
+     * we need to run configuration after the project is evaluated. At the same time, we need to
+     * squeeze our configuration before the {@code LaunchProtoData} task is configured. This means
+     * adding the {@code afterEvaluate(..)} hook before the ProtoData Gradle plugin is applied to
+     * the project.
+     */
     @Override
     public void apply(Project target) {
         target.afterEvaluate(ProtoDataConfigPlugin::configureProtoData);

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.90</version>
+<version>2.0.0-SNAPSHOT.91</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -36,5 +36,5 @@ val mcVersion by extra("2.0.0-SNAPSHOT.88")
  */
 val validationVersion by extra("2.0.0-SNAPSHOT.12")
 
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.90")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.91")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
Previously, when we turned off validation codegen, we still run all the Gradle config. Now we skip everything except actually applying ProtoData. If the users don't need ProtoData for any other generation purposes, they may disable ProtoData tasks manually.