### PR TITLE
Newer `logging`, remove redundant cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@
 @file:Suppress("RemoveRedundantQualifierName") // To prevent IDEA replacing FQN imports.
 
 import io.spine.internal.dependency.Protobuf
-import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Validation
 import io.spine.internal.gradle.RunBuild
 import io.spine.internal.gradle.publish.PublishingRepos
@@ -38,8 +37,6 @@ import io.spine.internal.gradle.report.license.LicenseReporter
 import io.spine.internal.gradle.report.pom.PomGenerator
 import io.spine.internal.gradle.standardToSpineSdk
 import java.time.Duration
-import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool
 
 buildscript {
     standardSpineSdkRepositories()

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -51,7 +51,7 @@ object Spine {
         const val reflect = "2.0.0-SNAPSHOT.182"
 
         /** The version of [Spine.logging]. */
-        const val logging = "2.0.0-SNAPSHOT.183"
+        const val logging = "2.0.0-SNAPSHOT.186"
 
         /** The version of [Spine.testlib]. */
         const val testlib = "2.0.0-SNAPSHOT.183"
@@ -70,10 +70,10 @@ object Spine {
         const val mcJava = "2.0.0-SNAPSHOT.147"
 
         /** The version of [Spine.baseTypes]. */
-        const val baseTypes = "2.0.0-SNAPSHOT.120"
+        const val baseTypes = "2.0.0-SNAPSHOT.121"
 
         /** The version of [Spine.time]. */
-        const val time = "2.0.0-SNAPSHOT.121"
+        const val time = "2.0.0-SNAPSHOT.131"
 
         /** The version of [Spine.change]. */
         const val change = "2.0.0-SNAPSHOT.118"

--- a/license-report.md
+++ b/license-report.md
@@ -865,7 +865,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:22 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1520,7 +1520,7 @@ This report was generated on **Thu Jun 08 19:33:22 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2167,7 +2167,7 @@ This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2888,7 +2888,7 @@ This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3724,7 +3724,7 @@ This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4371,7 +4371,7 @@ This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:29 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5085,7 +5085,7 @@ This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5740,7 +5740,7 @@ This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6386,4 +6386,4 @@ This report was generated on **Thu Jun 08 19:33:25 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 19:33:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 20:57:30 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -865,12 +865,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:22 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1520,12 +1520,12 @@ This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2167,12 +2167,12 @@ This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
@@ -2888,12 +2888,12 @@ This report was generated on **Thu Jun 08 01:58:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3724,12 +3724,12 @@ This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -4371,12 +4371,12 @@ This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -5085,12 +5085,12 @@ This report was generated on **Thu Jun 08 01:58:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:59:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5740,12 +5740,12 @@ This report was generated on **Thu Jun 08 01:59:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:59:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.149`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.150`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6386,4 +6386,4 @@ This report was generated on **Thu Jun 08 01:59:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 08 01:59:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Jun 08 19:33:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java-annotation/src/test/resources/annotator-plugin-test/typedefs/build.gradle.kts
+++ b/mc-java-annotation/src/test/resources/annotator-plugin-test/typedefs/build.gradle.kts
@@ -32,28 +32,3 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool
 
 tasks.processResources.get().duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-val generatedSourceProto = "$buildDir/generated/source/proto"
-
-/**
- * Remove the generated vanilla proto code.
- */
-project.afterEvaluate {
-    val generatedSourceProtoDir = File(generatedSourceProto)
-    val notInSourceDir: (File) -> Boolean = { file -> !file.residesIn(generatedSourceProtoDir) }
-
-    tasks.withType<JavaCompile>().forEach {
-        it.source = it.source.filter(notInSourceDir).asFileTree
-    }
-
-    tasks.withType<KotlinCompile<*>>().forEach {
-        val thisTask = it as KotlinCompileTool
-        val filteredKotlin = thisTask.sources.filter(notInSourceDir).toSet()
-        with(thisTask.sources as ConfigurableFileCollection) {
-            setFrom(filteredKotlin)
-        }
-    }
-}
-
-fun File.residesIn(directory: File): Boolean =
-    canonicalFile.startsWith(directory.absolutePath)

--- a/mc-java-base/build.gradle.kts
+++ b/mc-java-base/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(gradleApi())
     compileOnlyApi(gradleKotlinDsl())
 
+    api(Spine.logging)
     api(Spine.modelCompiler)
     api(Validation.config)
     api(Validation.runtime)

--- a/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/TempArtifactDirs.java
+++ b/mc-java-base/src/main/java/io/spine/tools/mc/java/gradle/TempArtifactDirs.java
@@ -27,7 +27,8 @@
 package io.spine.tools.mc.java.gradle;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.flogger.FluentLogger;
+import io.spine.logging.Logger;
+import io.spine.logging.LoggingFactory;
 import io.spine.tools.java.fs.DefaultJavaPaths;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.gradle.api.Project;
@@ -40,14 +41,18 @@ import java.util.List;
 import static io.spine.tools.mc.java.gradle.McJavaOptions.def;
 import static io.spine.tools.mc.java.gradle.Projects.getMcJava;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * Calculates directories to be cleaned for a given project.
  */
 public class TempArtifactDirs {
 
-    private static final FluentLogger log = FluentLogger.forEnclosingClass();
+    private static final Logger<?> log = LoggingFactory.getLogger(
+            getKotlinClass(TempArtifactDirs.class)
+    );
 
     /** Prevents instantiation of this utility class. */
     private TempArtifactDirs() {
@@ -62,13 +67,13 @@ public class TempArtifactDirs {
         result.addAll(tempArtifactDirsOf(project));
         var dirs = fromOptionsOf(project);
         if (!dirs.isEmpty()) {
-            log.atFine()
-               .log("Found %d directories to clean: `%s`.", dirs.size(), dirs);
+            log.atDebug()
+               .log(() -> format("Found %d directories to clean: `%s`.", dirs.size(), dirs));
             result.addAll(dirs);
         } else {
             var defaultValue = def(project).generated().toString();
-            log.atFine()
-               .log("Default directory to clean: `%s`.", defaultValue);
+            log.atDebug()
+               .log(() -> format("Default directory to clean: `%s`.", defaultValue));
             result.add(new File(defaultValue));
         }
         return result.build();

--- a/mc-java-protoc/build.gradle.kts
+++ b/mc-java-protoc/build.gradle.kts
@@ -79,28 +79,3 @@ tasks.jar {
 
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
-
-val generatedSourceProto = "$buildDir/generated/source/proto"
-
-/**
- * Remove the generated vanilla proto code.
- */
-project.afterEvaluate {
-    val generatedSourceProtoDir = File(generatedSourceProto)
-    val notInSourceDir: (File) -> Boolean = { file -> !file.residesIn(generatedSourceProtoDir) }
-
-    tasks.withType<JavaCompile>().forEach {
-        it.source = it.source.filter(notInSourceDir).asFileTree
-    }
-
-    tasks.withType<KotlinCompile<*>>().forEach {
-        val thisTask = it as KotlinCompileTool
-        val filteredKotlin = thisTask.sources.filter(notInSourceDir).toSet()
-        with(thisTask.sources as ConfigurableFileCollection) {
-            setFrom(filteredKotlin)
-        }
-    }
-}
-
-fun File.residesIn(directory: File): Boolean =
-    canonicalFile.startsWith(directory.absolutePath)

--- a/mc-java-rejection/src/test/resources/rejections-gen-plugin-test/sub-module/build.gradle.kts
+++ b/mc-java-rejection/src/test/resources/rejections-gen-plugin-test/sub-module/build.gradle.kts
@@ -47,28 +47,3 @@ dependencies {
 }
 
 tasks.processResources.get().duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-/**
- * Exclude generated vanilla proto code from inputs of `JavaCompile` and `KotlinCompile`.
- */
-val generatedSourceProto = "$buildDir/generated/source/proto"
-
-project.afterEvaluate {
-    val generatedSourceProtoDir = File(generatedSourceProto)
-    val notInSourceDir: (File) -> Boolean = { file -> !file.residesIn(generatedSourceProtoDir) }
-
-    tasks.withType<JavaCompile>().forEach {
-        it.source = it.source.filter(notInSourceDir).asFileTree
-    }
-
-    tasks.withType<KotlinCompile<*>>().forEach {
-        val thisTask = it as KotlinCompileTool
-        val filteredKotlin = thisTask.sources.filter(notInSourceDir).toSet()
-        with(thisTask.sources as ConfigurableFileCollection) {
-            setFrom(filteredKotlin)
-        }
-    }
-}
-
-fun File.residesIn(directory: File): Boolean =
-    canonicalFile.startsWith(directory.absolutePath)

--- a/mc-java-validation/src/test/resources/validation-gen-plugin-test/build.gradle.kts
+++ b/mc-java-validation/src/test/resources/validation-gen-plugin-test/build.gradle.kts
@@ -88,28 +88,3 @@ sourceSets {
         (extensions.getByName("proto") as SourceDirectorySet).srcDir("$projectDir/src/main/proto")
     }
 }
-
-val generatedSourceProto = "$buildDir/generated/source/proto"
-
-/**
- * Remove the generated vanilla proto code.
- */
-project.afterEvaluate {
-    val generatedSourceProtoDir = File(generatedSourceProto)
-    val notInSourceDir: (File) -> Boolean = { file -> !file.residesIn(generatedSourceProtoDir) }
-
-    tasks.withType<JavaCompile>().forEach {
-        it.source = it.source.filter(notInSourceDir).asFileTree
-    }
-
-    tasks.withType<KotlinCompile<*>>().forEach {
-        val thisTask = it as KotlinCompileTool
-        val filteredKotlin = thisTask.sources.filter(notInSourceDir).toSet()
-        with(thisTask.sources as ConfigurableFileCollection) {
-            setFrom(filteredKotlin)
-        }
-    }
-}
-
-fun File.residesIn(directory: File): Boolean =
-    canonicalFile.startsWith(directory.absolutePath)

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/CleaningPlugin.java
@@ -25,6 +25,7 @@
  */
 package io.spine.tools.mc.java.gradle.plugins;
 
+import com.google.common.base.Joiner;
 import io.spine.tools.gradle.task.GradleTask;
 import io.spine.tools.mc.java.gradle.TempArtifactDirs;
 import org.gradle.api.Action;
@@ -34,7 +35,6 @@ import org.gradle.api.Task;
 
 import java.io.File;
 
-import static com.google.common.flogger.LazyArgs.lazy;
 import static io.spine.io.Delete.deleteRecursively;
 import static io.spine.tools.gradle.task.BaseTaskName.clean;
 import static io.spine.tools.mc.java.gradle.McJavaTaskName.preClean;
@@ -71,9 +71,10 @@ public final class CleaningPlugin implements Plugin<Project> {
         public void execute(Task task) {
             var logger = project.getLogger();
             var dirsToClean = TempArtifactDirs.getFor(project);
-            logger.debug(
-                    "Pre-clean: deleting the directories (`{}`).", lazy(dirsToClean::toString)
-            );
+            if (logger.isDebugEnabled()) {
+                var dirs = Joiner.on(", ").join(dirsToClean);
+                logger.debug("Pre-clean: deleting the directories (`{}`).", dirs);
+            }
             dirsToClean.stream()
                     .map(File::toPath)
                     .forEach(dir -> {
@@ -83,4 +84,3 @@ public final class CleaningPlugin implements Plugin<Project> {
         }
     }
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.184</version>
+    <version>2.0.0-SNAPSHOT.186</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -74,7 +74,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>2.0.0-SNAPSHOT.121</version>
+    <version>2.0.0-SNAPSHOT.131</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.149</version>
+<version>2.0.0-SNAPSHOT.150</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -229,29 +229,4 @@ subprojects {
     //TODO:2021-07-22:alexander.yevsyukov: Turn to WARN and investigate duplicates.
     // see https://github.com/SpineEventEngine/base/issues/657
     tasks.processTestResources.get().duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-    fun File.residesIn(directory: File): Boolean =
-        canonicalFile.startsWith(directory.absolutePath)
-
-    /**
-     * Exclude generated vanilla proto code from inputs of `JavaCompile` and `KotlinCompile`.
-     */
-    val generatedSourceProto = "$buildDir/generated/source/proto"
-
-    project.afterEvaluate {
-        val generatedSourceProtoDir = File(generatedSourceProto)
-        val notInSourceDir: (File) -> Boolean = { file -> !file.residesIn(generatedSourceProtoDir) }
-
-        tasks.withType<JavaCompile>().forEach {
-            it.source = it.source.filter(notInSourceDir).asFileTree
-        }
-
-        tasks.withType<KotlinCompile<*>>().forEach {
-            val thisTask = it as KotlinCompileTool
-            val filteredKotlin = thisTask.sources.filter(notInSourceDir).toSet()
-            with(thisTask.sources as ConfigurableFileCollection) {
-                setFrom(filteredKotlin)
-            }
-        }
-    }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,5 +32,5 @@
  * For versions of Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  * Keep in mind that changind it under `buildSrc` also requires sync. with `tests/buildSrc`.
  */
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.149")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.150")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This PR:
  * Bumps `spine-logging` dependency, applying its API to some of the classes, which are going to be used when migrating codegen to ProtoData.
  * Removes the build code which always removes of vanilla Protobuf code. This is no longer needed because recent ProtoData versions mostly handle the duplicated code issue.
