### PR TITLE
Improve rejection code

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -866,7 +866,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:12 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1624,7 +1624,7 @@ This report was generated on **Sat Jul 08 20:14:03 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2374,7 +2374,7 @@ This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:13 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3095,7 +3095,7 @@ This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3932,7 +3932,7 @@ This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4682,7 +4682,7 @@ This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:14 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5396,7 +5396,7 @@ This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:15 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6154,7 +6154,7 @@ This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:15 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6800,4 +6800,4 @@ This report was generated on **Sat Jul 08 20:14:06 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 20:14:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jul 10 11:37:15 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -866,12 +866,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:55 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -1624,12 +1624,12 @@ This report was generated on **Thu Jul 06 17:15:57 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -2374,12 +2374,12 @@ This report was generated on **Thu Jul 06 17:15:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
@@ -3095,12 +3095,12 @@ This report was generated on **Thu Jul 06 17:15:58 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -3932,12 +3932,12 @@ This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -4682,12 +4682,12 @@ This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -5396,12 +5396,12 @@ This report was generated on **Thu Jul 06 17:15:59 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:16:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
@@ -6154,12 +6154,12 @@ This report was generated on **Thu Jul 06 17:16:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:16:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -6800,4 +6800,4 @@ This report was generated on **Thu Jul 06 17:16:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 06 17:16:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Jul 07 14:38:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -866,7 +866,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1624,7 +1624,7 @@ This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2374,7 +2374,7 @@ This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3095,7 +3095,7 @@ This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:04 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3932,7 +3932,7 @@ This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4682,7 +4682,7 @@ This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5396,7 +5396,7 @@ This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:05 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6154,7 +6154,7 @@ This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6800,4 +6800,4 @@ This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 20:14:06 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -866,7 +866,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:55 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1624,7 +1624,7 @@ This report was generated on **Fri Jul 07 14:38:55 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:00 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2374,7 +2374,7 @@ This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3095,7 +3095,7 @@ This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3932,7 +3932,7 @@ This report was generated on **Fri Jul 07 14:38:56 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4682,7 +4682,7 @@ This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5396,7 +5396,7 @@ This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6154,7 +6154,7 @@ This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6800,4 +6800,4 @@ This report was generated on **Fri Jul 07 14:38:57 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 07 14:38:58 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jul 08 02:27:02 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java-annotation/src/test/resources/annotator-plugin-test/settings.gradle.kts
+++ b/mc-java-annotation/src/test/resources/annotator-plugin-test/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/mc-java-checks/src/main/java/io/spine/tools/mc/java/checks/gradle/McJavaChecksPlugin.java
+++ b/mc-java-checks/src/main/java/io/spine/tools/mc/java/checks/gradle/McJavaChecksPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.mc.java.rejection
+
+import com.squareup.javapoet.CodeBlock
+import io.spine.protodata.MessageType
+import io.spine.tools.java.javadoc.JavadocText
+
+/**
+ * Pieces of Javadoc code used in the generated code.
+ */
+internal object Javadoc {
+
+    const val NEW_BUILDER_METHOD_ABSTRACT = "Creates a new builder for the rejection."
+    const val BUILD_METHOD_ABSTRACT = "Creates the rejection from the builder and validates it."
+
+    private const val REJECTION_MESSAGE_METHOD_ABSTRACT = "Obtains the rejection and validates it."
+    private const val BUILDER_CONSTRUCTOR_ABSTRACT = "Prevent direct instantiation of the builder."
+
+    private const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
+
+    val newBuilderMethodAbstract: String by lazy {
+        JavadocText.fromEscaped(NEW_BUILDER_METHOD_ABSTRACT)
+            .withNewLine()
+            .value
+    }
+
+    val builderConstructor: String by lazy {
+        JavadocText.fromEscaped(BUILDER_CONSTRUCTOR_ABSTRACT).withNewLine().value
+    }
+
+    val rejectionMessage: String by lazy {
+        JavadocText.fromEscaped(REJECTION_MESSAGE_METHOD_ABSTRACT).withNewLine().value
+    }
+
+    val buildMethod: String by lazy {
+        JavadocText.fromEscaped(BUILD_METHOD_ABSTRACT).withNewLine().value
+    }
+
+    fun forType(messageType: MessageType): String {
+        val rejectionName = messageType.name.simpleName
+        val javadocText = CodeBlock.builder()
+            .add(BUILDER_ABSTRACT_TEMPLATE, rejectionName)
+            .build()
+            .toString()
+        return JavadocText.fromEscaped(javadocText)
+            .withNewLine()
+            .value
+    }
+}

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -74,13 +74,11 @@ internal object Javadoc {
      * Generated Javadoc for the `RejectionThrowable` class corresponding
      * the given rejection type.
      */
-    fun forThrowableOf(rejection: MessageType): CodeBlock {
+    fun forThrowableOf(rejection: MessageType): CodeBlock = codeBlock {
         val javadocAbstract = classAbstractFor(rejection)
         val protoSourceNote = protoMessageNote(rejection)
-        return CodeBlock.builder()
-            .add(javadocAbstract)
-            .add(protoSourceNote)
-            .build()
+        add(javadocAbstract)
+        add(protoSourceNote)
     }
 
     /**
@@ -89,17 +87,15 @@ internal object Javadoc {
      * @param builder
      *          the name of a rejection builder parameter.
      */
-    fun forConstructorOfThrowable(builder: ParameterSpec): CodeBlock {
+    fun forConstructorOfThrowable(builder: ParameterSpec): CodeBlock = codeBlock {
         val generalPart = fromUnescaped("Creates a new instance.")
             .withNewLine()
             .withNewLine()
         val paramsPart = fromEscaped(codeBlock(
-                "@param \$N the builder for the rejection", builder
-            )).withNewLine()
-        return codeBlock {
-            add(generalPart.value())
-            add(paramsPart.value())
-        }
+            "@param \$N the builder for the rejection", builder
+        )).withNewLine()
+        add(generalPart.value())
+        add(paramsPart.value())
     }
 
     /**
@@ -107,12 +103,10 @@ internal object Javadoc {
      * class corresponding the given rejection type.
      */
     fun forBuilderOf(rejection: MessageType): String {
-        val rejectionName = rejection.name.simpleName
-        val javadocText = CodeBlock.builder()
-            .add(BUILDER_ABSTRACT_TEMPLATE, rejectionName)
-            .build()
-            .toString()
-        return fromEscaped(javadocText)
+        val javadocText = codeBlock {
+            add(BUILDER_ABSTRACT_TEMPLATE, rejection.name.simpleName)
+        }
+        return fromEscaped(javadocText.toString())
             .withNewLine()
             .value
     }

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -48,7 +48,7 @@ internal object Javadoc {
     @VisibleForTesting
     const val BUILD_METHOD_ABSTRACT = "Creates the rejection from the builder and validates it."
 
-    private const val REJECTION_MESSAGE_METHOD_ABSTRACT = "Obtains the rejection and validates it."
+    private const val REJECTION_MESSAGE_METHOD_ABSTRACT = "Obtains the rejection message."
     private const val BUILDER_CONSTRUCTOR_ABSTRACT = "Prevent direct instantiation of the builder."
     private const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
 
@@ -75,10 +75,8 @@ internal object Javadoc {
      * the given rejection type.
      */
     fun forThrowableOf(rejection: MessageType): CodeBlock = codeBlock {
-        val javadocAbstract = classAbstractFor(rejection)
-        val protoSourceNote = protoMessageNote(rejection)
-        add(javadocAbstract)
-        add(protoSourceNote)
+        add(classAbstractFor(rejection))
+        add(protoMessageNote(rejection))
     }
 
     /**

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -50,7 +50,9 @@ internal object Javadoc {
 
     private const val REJECTION_MESSAGE_METHOD_ABSTRACT = "Obtains the rejection message."
     private const val BUILDER_CONSTRUCTOR_ABSTRACT = "Prevent direct instantiation of the builder."
-    private const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
+
+    @VisibleForTesting
+    const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
 
     val ofNewBuilderMethod: String by lazy {
         fromEscaped(NEW_BUILDER_METHOD_ABSTRACT)

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -35,7 +35,7 @@ import io.spine.tools.java.javadoc.JavadocText.fromUnescaped
 import io.spine.tools.mc.java.rejection.Javadoc.PROTO_MESSAGE_NOTE_TEMPLATE
 
 /**
- * Pieces of Javadoc code used in the generated code.
+ * Pieces of Javadoc code used in the generated code of rejections.
  */
 internal object Javadoc {
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -86,7 +86,7 @@ internal object Javadoc {
      *          the name of a rejection builder parameter.
      */
     fun forConstructorOfThrowable(builder: ParameterSpec): CodeBlock = codeBlock {
-        val generalPart = fromUnescaped("Creates a new instance.")
+        val generalPart = fromEscaped("Creates a new instance.")
             .withNewLine()
             .withNewLine()
         val paramsPart = fromEscaped(codeBlock(

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -140,13 +140,16 @@ private fun classAbstractFor(messageType: MessageType): String {
     return javadoc.value
 }
 
+/**
+ * Obtains a Javadoc note about the rejection message type which is used together
+ * with a `RejectionThrowable` class.
+ */
 private fun protoMessageNote(messageType: MessageType): String {
     val protoType = messageType.name
-    val protoMessageNote = CodeBlock.builder()
-        .add(PROTO_MESSAGE_NOTE_TEMPLATE, protoType.packageName, protoType.simpleName)
-        .build()
-        .toString()
-    return fromEscaped(protoMessageNote)
+    val protoMessageNote = codeBlock {
+        add(PROTO_MESSAGE_NOTE_TEMPLATE, protoType.packageName, protoType.simpleName)
+    }
+    return fromEscaped(protoMessageNote.toString())
         .withNewLine()
         .value
 }

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -26,49 +26,105 @@
 
 package io.spine.tools.mc.java.rejection
 
+import com.google.common.annotations.VisibleForTesting
 import com.squareup.javapoet.CodeBlock
 import io.spine.protodata.MessageType
 import io.spine.tools.java.javadoc.JavadocText
+import io.spine.tools.java.javadoc.JavadocText.fromEscaped
+import io.spine.tools.mc.java.rejection.Javadoc.PROTO_MESSAGE_NOTE_TEMPLATE
 
 /**
  * Pieces of Javadoc code used in the generated code.
  */
 internal object Javadoc {
 
+    const val PROTO_MESSAGE_NOTE_TEMPLATE =
+        "<p>The rejection message proto type is {@code \$L.\$L}."
+
+    @VisibleForTesting
     const val NEW_BUILDER_METHOD_ABSTRACT = "Creates a new builder for the rejection."
+
+    @VisibleForTesting
     const val BUILD_METHOD_ABSTRACT = "Creates the rejection from the builder and validates it."
 
     private const val REJECTION_MESSAGE_METHOD_ABSTRACT = "Obtains the rejection and validates it."
     private const val BUILDER_CONSTRUCTOR_ABSTRACT = "Prevent direct instantiation of the builder."
-
     private const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
 
     val newBuilderMethodAbstract: String by lazy {
-        JavadocText.fromEscaped(NEW_BUILDER_METHOD_ABSTRACT)
+        fromEscaped(NEW_BUILDER_METHOD_ABSTRACT)
             .withNewLine()
             .value
     }
 
     val builderConstructor: String by lazy {
-        JavadocText.fromEscaped(BUILDER_CONSTRUCTOR_ABSTRACT).withNewLine().value
+        fromEscaped(BUILDER_CONSTRUCTOR_ABSTRACT).withNewLine().value
     }
 
     val rejectionMessage: String by lazy {
-        JavadocText.fromEscaped(REJECTION_MESSAGE_METHOD_ABSTRACT).withNewLine().value
+        fromEscaped(REJECTION_MESSAGE_METHOD_ABSTRACT).withNewLine().value
     }
 
     val buildMethod: String by lazy {
-        JavadocText.fromEscaped(BUILD_METHOD_ABSTRACT).withNewLine().value
+        fromEscaped(BUILD_METHOD_ABSTRACT).withNewLine().value
     }
 
-    fun forType(messageType: MessageType): String {
-        val rejectionName = messageType.name.simpleName
+    fun forBuilderOf(rejection: MessageType): String {
+        val rejectionName = rejection.name.simpleName
         val javadocText = CodeBlock.builder()
             .add(BUILDER_ABSTRACT_TEMPLATE, rejectionName)
             .build()
             .toString()
-        return JavadocText.fromEscaped(javadocText)
+        return fromEscaped(javadocText)
             .withNewLine()
             .value
     }
+
+    /**
+     * A Javadoc content for the rejection.
+     *
+     * @return the class-level Javadoc content
+     */
+    fun classJavadocFor(rejection: MessageType): CodeBlock {
+        val javadocAbstract = classAbstractFor(rejection)
+        val protoSourceNote = protoMessageNote(rejection)
+        return CodeBlock.builder()
+            .add(javadocAbstract)
+            .add(protoSourceNote)
+            .build()
+    }
 }
+
+/**
+ * Obtains the first paragraph of the rejection Javadoc.
+ *
+ * The text is taken as a leading comment of the rejection message
+ * declaration wrapped in `<pre>` tags.
+ */
+private fun classAbstractFor(messageType: MessageType): String {
+    val leadingComment = messageType.doc.leadingComment
+    if (leadingComment.isEmpty()) {
+        return ""
+    }
+    val javadoc = JavadocText.fromUnescaped(
+        // Add line separator to simulate behavior of native Protobuf API.
+        leadingComment + System.lineSeparator())
+        // Wrap the comment in `<pre>` tags similarly to how Protobuf does
+        // it for Javadocs of message types.
+        .inPreTags()
+        // Add new line to separate the comment from the rest of the Javadoc.
+        .withNewLine()
+    return javadoc.value
+}
+
+private fun protoMessageNote(messageType: MessageType): String {
+    val protoType = messageType.name
+    val protoMessageNote = CodeBlock.builder()
+        .add(PROTO_MESSAGE_NOTE_TEMPLATE, protoType.packageName, protoType.simpleName)
+        .build()
+        .toString()
+    return fromEscaped(protoMessageNote)
+        .withNewLine()
+        .value
+}
+

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -52,21 +52,21 @@ internal object Javadoc {
     private const val BUILDER_CONSTRUCTOR_ABSTRACT = "Prevent direct instantiation of the builder."
     private const val BUILDER_ABSTRACT_TEMPLATE = "The builder for the {@code \$L} rejection."
 
-    val newBuilderMethod: String by lazy {
+    val ofNewBuilderMethod: String by lazy {
         fromEscaped(NEW_BUILDER_METHOD_ABSTRACT)
             .withNewLine()
             .value
     }
 
-    val builderConstructor: String by lazy {
+    val ofBuilderConstructor: String by lazy {
         fromEscaped(BUILDER_CONSTRUCTOR_ABSTRACT).withNewLine().value
     }
 
-    val rejectionMessageMethod: String by lazy {
+    val ofRejectionMessageMethod: String by lazy {
         fromEscaped(REJECTION_MESSAGE_METHOD_ABSTRACT).withNewLine().value
     }
 
-    val buildMethod: String by lazy {
+    val ofBuildMethod: String by lazy {
         fromEscaped(BUILD_METHOD_ABSTRACT).withNewLine().value
     }
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Javadoc.kt
@@ -77,7 +77,7 @@ internal object Javadoc {
      * the given rejection type.
      */
     fun forThrowableOf(rejection: MessageType): CodeBlock = codeBlock {
-        add(classAbstractFor(rejection))
+        add(classSummaryFor(rejection))
         add(protoMessageNote(rejection))
     }
 
@@ -118,7 +118,7 @@ internal object Javadoc {
  * The text is taken as a leading comment of the rejection message
  * declaration wrapped in `<pre>` tags.
  */
-private fun classAbstractFor(messageType: MessageType): String {
+private fun classSummaryFor(messageType: MessageType): String {
     val leadingComment = messageType.doc.leadingComment
     if (leadingComment.isEmpty()) {
         return ""
@@ -147,4 +147,3 @@ private fun protoMessageNote(messageType: MessageType): String {
         .withNewLine()
         .value
 }
-

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Method.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Method.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package io.spine.tools.mc.java.rejection
 
 import com.google.errorprone.annotations.Immutable
 import io.spine.tools.java.code.Method
+
+/**
+ * Method names used in the generated code.
+ */
+internal object Method {
+    const val NEW_BUILDER = "newBuilder"
+    const val REJECTION_MESSAGE = "rejectionMessage"
+    const val BUILD = "build"
+}
 
 /**
  * A reference to a method with no arguments.
@@ -42,6 +52,7 @@ internal class NoArgMethod(methodName: String) : Method(methodName) {
         return value() + "()"
     }
 
+    @Suppress("ConstPropertyName") // As required by Java conventions for serialization.
     companion object {
         private const val serialVersionUID = 0L
     }

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Methods.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/Methods.kt
@@ -23,7 +23,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package io.spine.tools.mc.java.rejection
 
 import com.google.errorprone.annotations.Immutable

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/PoetExts.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/PoetExts.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.mc.java.rejection
+
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+
+/**
+ * Creates a new [MethodSpec] with via customizing it using
+ * the given [action] on the builder.
+ *
+ * @param name
+ *         The name of the method.
+ * @param action
+ *         The action to be performed on the [MethodSpec.Builder].
+ */
+internal fun methodSpec(name: String, action: MethodSpec.Builder.() -> Unit): MethodSpec {
+    val builder = MethodSpec.methodBuilder(name)
+    action(builder)
+    return builder.build()
+}
+
+/**
+ * Creates a [TypeSpec] for a class with the given name. The class is customized via the given
+ * builder action.
+ *
+ * @param name
+ *         The name of the class.
+ * @param action
+ *         The action on the builder to create the class.
+ */
+internal fun classSpec(name: String, action: TypeSpec.Builder.() -> Unit): TypeSpec {
+    val builder = TypeSpec.classBuilder(name)
+    action(builder)
+    return builder.build()
+}
+
+/**
+ * Creates a [MethodSpec] for a parameterless constructor with the given action on the builder.
+ */
+internal fun constructorSpec(action: MethodSpec.Builder.() -> Unit): MethodSpec {
+    val builder = MethodSpec.constructorBuilder()
+    action(builder)
+    return builder.build()
+}
+
+/**
+ * Creates a [CodeBlock] with the given action on the builder.
+ */
+internal fun codeBlock(action: CodeBlock.Builder.() -> Unit): CodeBlock {
+    val builder = CodeBlock.builder()
+    action(builder)
+    return builder.build()
+}

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/PoetExts.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/PoetExts.kt
@@ -77,3 +77,9 @@ internal fun codeBlock(action: CodeBlock.Builder.() -> Unit): CodeBlock {
     action(builder)
     return builder.build()
 }
+
+/**
+ * A shortcut for [CodeBlock.of] converted to `String`.
+ */
+internal fun codeBlock(format: String, vararg args: Any): String =
+    CodeBlock.of(format, *args).toString()

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -81,11 +81,11 @@ internal class RThrowableBuilderCode internal constructor(
     private val typeSystem: TypeSystem
 ) : BuilderSpec {
 
-    private val simpleClassName: SimpleClassName = SimpleClassName.ofBuilder()
+    private val simpleClassName: String = SimpleClassName.ofBuilder().value
 
     override fun packageName(): PackageName = rejection.javaPackage()
 
-    override fun toPoet(): TypeSpec = classSpec(simpleClassName.value()) {
+    override fun toPoet(): TypeSpec = classSpec(simpleClassName) {
         addModifiers(PUBLIC, STATIC)
         addJavadoc(forBuilderOf(rejection))
         addField(messageClass.builderField())
@@ -107,7 +107,7 @@ internal class RThrowableBuilderCode internal constructor(
         addModifiers(PUBLIC, STATIC)
         addJavadoc(ofNewBuilderMethod)
         returns(builderClass())
-        addStatement("return new \$L()", simpleClassName.value())
+        addStatement("return new \$L()", simpleClassName)
     }
 
     /**
@@ -181,7 +181,7 @@ internal class RThrowableBuilderCode internal constructor(
      * Obtains the class name of the builder to generate.
      */
     private fun builderClass(): ClassName =
-        throwableClass.nestedClass(simpleClassName.value())
+        throwableClass.nestedClass(simpleClassName)
 }
 
 private val newBuilder = NoArgMethod(NEW_BUILDER)

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -51,6 +51,11 @@ import io.spine.tools.java.code.BuilderSpec.RETURN_STATEMENT
 import io.spine.tools.java.javadoc.JavadocText
 import io.spine.tools.mc.java.field.RepeatedFieldType
 import io.spine.tools.mc.java.field.SingularFieldType.constructTypeNameFor
+import io.spine.tools.mc.java.rejection.Javadoc.forBuilderOf
+import io.spine.tools.mc.java.rejection.Javadoc.ofBuildMethod
+import io.spine.tools.mc.java.rejection.Javadoc.ofBuilderConstructor
+import io.spine.tools.mc.java.rejection.Javadoc.ofNewBuilderMethod
+import io.spine.tools.mc.java.rejection.Javadoc.ofRejectionMessageMethod
 import io.spine.tools.mc.java.rejection.Method.BUILD
 import io.spine.tools.mc.java.rejection.Method.NEW_BUILDER
 import io.spine.tools.mc.java.rejection.Method.REJECTION_MESSAGE
@@ -82,7 +87,7 @@ internal class RThrowableBuilderCode internal constructor(
 
     override fun toPoet(): TypeSpec = classSpec(simpleClassName.value()) {
         addModifiers(PUBLIC, STATIC)
-        addJavadoc(Javadoc.forBuilderOf(rejection))
+        addJavadoc(forBuilderOf(rejection))
         addField(messageClass.builderField())
         addMethod(constructor())
         addMethods(setters())
@@ -100,7 +105,7 @@ internal class RThrowableBuilderCode internal constructor(
      */
     fun newBuilder(): MethodSpec = methodSpec(newBuilder.name()) {
         addModifiers(PUBLIC, STATIC)
-        addJavadoc(Javadoc.newBuilderMethod)
+        addJavadoc(ofNewBuilderMethod)
         returns(builderClass())
         addStatement("return new \$L()", simpleClassName.value())
     }
@@ -183,7 +188,7 @@ private val newBuilder = NoArgMethod(NEW_BUILDER)
 private const val BUILDER_FIELD = "builder"
 
 private fun constructor(): MethodSpec = constructorSpec {
-    addJavadoc(Javadoc.builderConstructor)
+    addJavadoc(ofBuilderConstructor)
     addModifiers(PRIVATE)
 }
 
@@ -242,7 +247,7 @@ private fun PoClassName.builderField(): FieldSpec {
 private fun PoClassName.buildMethod(): MethodSpec = methodSpec(BUILD) {
     val messageClass = this@buildMethod
     addModifiers(PUBLIC)
-    addJavadoc(Javadoc.buildMethod)
+    addJavadoc(ofBuildMethod)
     returns(messageClass)
     addStatement("return new \$T(this)", messageClass)
 }
@@ -259,7 +264,7 @@ private fun PoClassName.rejectionMessageMethod(): MethodSpec = methodSpec(REJECT
         AnnotationSpec.builder(Validated::class.java).build()
     )
     addModifiers(PRIVATE)
-    addJavadoc(Javadoc.rejectionMessageMethod)
+    addJavadoc(ofRejectionMessageMethod)
     returns(annotatedType)
     addStatement("return \$L.build()", BUILDER_FIELD)
 }

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -82,7 +82,7 @@ internal class RThrowableBuilderCode internal constructor(
 
     override fun toPoet(): TypeSpec = classSpec(simpleClassName.value()) {
         addModifiers(PUBLIC, STATIC)
-        addJavadoc(Javadoc.forType(rejection))
+        addJavadoc(Javadoc.forBuilderOf(rejection))
         addField(messageClass.builderField())
         addMethod(constructor())
         addMethods(setters())

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -49,7 +49,7 @@ import io.spine.tools.java.code.BuilderSpec.RETURN_STATEMENT
 import io.spine.tools.java.javadoc.JavadocText
 import io.spine.tools.mc.java.field.RepeatedFieldType
 import io.spine.tools.mc.java.field.SingularFieldType.constructTypeNameFor
-import io.spine.tools.mc.java.rejection.KRThrowableBuilderSpec.Companion.NEW_BUILDER_METHOD_NAME
+import io.spine.tools.mc.java.rejection.RThrowableBuilderCode.Companion.NEW_BUILDER_METHOD_NAME
 import io.spine.validate.Validate
 import java.util.regex.Pattern
 import javax.lang.model.element.Modifier.FINAL
@@ -64,7 +64,7 @@ import com.squareup.javapoet.TypeName as PoTypeName
  *
  * A generated builder validates rejection messages using [Validate.check].
  */
-internal class KRThrowableBuilderSpec internal constructor(
+internal class RThrowableBuilderCode internal constructor(
     private val rejection: MessageType,
     private val messageClass: PoClassName,
     private val throwableClass: PoClassName,

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -27,6 +27,7 @@
 
 package io.spine.tools.mc.java.rejection
 
+import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
@@ -54,6 +55,7 @@ import io.spine.tools.mc.java.rejection.Method.BUILD
 import io.spine.tools.mc.java.rejection.Method.NEW_BUILDER
 import io.spine.tools.mc.java.rejection.Method.REJECTION_MESSAGE
 import io.spine.validate.Validate
+import io.spine.validate.Validated
 import java.util.regex.Pattern
 import javax.lang.model.element.Modifier.FINAL
 import javax.lang.model.element.Modifier.PRIVATE
@@ -253,11 +255,12 @@ private fun PoClassName.buildMethod(): MethodSpec = methodSpec(BUILD) {
  */
 private fun PoClassName.rejectionMessageMethod(): MethodSpec = methodSpec(REJECTION_MESSAGE) {
     val messageType = this@rejectionMessageMethod
+    val annotatedType = messageType.annotated(
+        AnnotationSpec.builder(Validated::class.java).build()
+    )
     addModifiers(PRIVATE)
     addJavadoc(Javadoc.rejectionMessage)
-    returns(messageType)
-    addStatement("\$T message = \$L.build()", messageType, BUILDER_FIELD)
-    addStatement("\$T.check(message)", Validate::class.java)
-    addStatement("return message")
+    returns(annotatedType)
+    addStatement("return \$L.build()", BUILDER_FIELD)
 }
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableBuilderCode.kt
@@ -100,7 +100,7 @@ internal class RThrowableBuilderCode internal constructor(
      */
     fun newBuilder(): MethodSpec = methodSpec(newBuilder.name()) {
         addModifiers(PUBLIC, STATIC)
-        addJavadoc(Javadoc.newBuilderMethodAbstract)
+        addJavadoc(Javadoc.newBuilderMethod)
         returns(builderClass())
         addStatement("return new \$L()", simpleClassName.value())
     }
@@ -259,7 +259,7 @@ private fun PoClassName.rejectionMessageMethod(): MethodSpec = methodSpec(REJECT
         AnnotationSpec.builder(Validated::class.java).build()
     )
     addModifiers(PRIVATE)
-    addJavadoc(Javadoc.rejectionMessage)
+    addJavadoc(Javadoc.rejectionMessageMethod)
     returns(annotatedType)
     addStatement("return \$L.build()", BUILDER_FIELD)
 }

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableCode.kt
@@ -36,6 +36,7 @@ import io.spine.protodata.MessageType
 import io.spine.tools.java.code.GeneratedBy
 import io.spine.tools.java.code.field.FieldName
 import io.spine.tools.java.javadoc.JavadocText
+import io.spine.tools.mc.java.rejection.Javadoc.classJavadocFor
 import javax.lang.model.element.Modifier.FINAL
 import javax.lang.model.element.Modifier.PRIVATE
 import javax.lang.model.element.Modifier.PUBLIC
@@ -75,7 +76,7 @@ internal class RThrowableCode(
 
     fun toPoet(): TypeSpec {
         return TypeSpec.classBuilder(simpleClassName)
-            .addJavadoc(classJavadoc())
+            .addJavadoc(classJavadocFor(rejection))
             .addAnnotation(GeneratedBy.spineModelCompiler())
             .addModifiers(PUBLIC)
             .superclass(RejectionThrowable::class.java)
@@ -113,56 +114,6 @@ internal class RThrowableCode(
             .returns(returnType)
             .addStatement("return (\$T) super.\$L", returnType, methodSignature)
             .build()
-    }
-
-    /**
-     * A Javadoc content for the rejection.
-     *
-     * @return the class-level Javadoc content
-     */
-    private fun classJavadoc(): CodeBlock {
-        val javadocAbstract = javadocAbstract()
-        val protoSourceNote = protoMessageNote()
-        return CodeBlock.builder()
-            .add(javadocAbstract)
-            .add(protoSourceNote)
-            .build()
-    }
-
-    /**
-     * Creates a piece of Javadoc referencing a proto message type which is
-     * used as a rejection message.
-     */
-    private fun protoMessageNote(): String {
-        val codeBlock = CodeBlock.builder()
-            .add("<p>The rejection message proto type is {@code \$L.\$L}",
-                rejection.name.packageName, simpleClassName)
-            .build()
-        val javadoc = JavadocText.fromEscaped(codeBlock.toString())
-            .withNewLine()
-        return javadoc.value
-    }
-
-    /**
-     * Obtains the first paragraph of the rejection Javadoc.
-     *
-     * The text is taken as a leading comment of the rejection message
-     * declaration wrapped in `<pre>` tags.
-     */
-    private fun javadocAbstract(): String {
-        val leadingComment = rejection.doc.leadingComment
-        if (leadingComment.isEmpty()) {
-            return ""
-        }
-        val javadoc = JavadocText.fromUnescaped(
-            // Add line separator to simulate behavior of native Protobuf API.
-            leadingComment + System.lineSeparator())
-            // Wrap the comment in `<pre>` tags similarly to how Protobuf does
-            // it for Javadocs of message types.
-            .inPreTags()
-            // Add new line to separate the comment from the rest of the Javadoc.
-            .withNewLine()
-        return javadoc.value
     }
 }
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableCode.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RThrowableCode.kt
@@ -25,17 +25,14 @@
  */
 package io.spine.tools.mc.java.rejection
 
-import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.MethodSpec
-import com.squareup.javapoet.ParameterSpec
 import com.squareup.javapoet.TypeSpec
 import io.spine.base.RejectionThrowable
 import io.spine.logging.WithLogging
 import io.spine.protodata.MessageType
 import io.spine.tools.java.code.GeneratedBy
 import io.spine.tools.java.code.field.FieldName
-import io.spine.tools.java.javadoc.JavadocText
 import io.spine.tools.mc.java.rejection.Javadoc.forConstructorOfThrowable
 import io.spine.tools.mc.java.rejection.Javadoc.forThrowableOf
 import javax.lang.model.element.Modifier.FINAL

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
@@ -39,7 +39,6 @@ import io.spine.protodata.codegen.java.JavaRenderer
 import io.spine.protodata.qualifiedName
 import io.spine.protodata.renderer.SourceFileSet
 import io.spine.string.ti
-import io.spine.tools.code.Indent
 import java.nio.file.Path
 
 /**
@@ -56,6 +55,15 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
 
     private lateinit var sources: SourceFileSet
 
+    private fun bakeTypeSystem(): TypeSystem = typeSystem {
+        select(ProtobufSourceFile::class.java).all().forEach { file ->
+            addFrom(file)
+        }
+        select(ProtobufDependency::class.java).all().forEach { dependency ->
+            addFrom(dependency.file)
+        }
+    }
+
     override fun render(sources: SourceFileSet) {
         // We could receive `grpc` or `kotlin` output roots here. Now we do only `java`.
         if (!sources.outputRoot.endsWith("java")) {
@@ -64,34 +72,14 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
         this.sources = sources
         val rejectionFiles = findRejectionFiles()
         rejectionFiles.forEach {
-            generateRejection(it)
-        }
-    }
-
-    private fun bakeTypeSystem(): TypeSystem =
-        TypeSystem.newBuilder().also {
-            addSourceFiles(it)
-            addDependencies(it)
-        }.build()
-
-    private fun addSourceFiles(types: TypeSystem.Builder) {
-        val files = select(ProtobufSourceFile::class.java).all()
-        for (file in files) {
-            types.addFrom(file)
-        }
-    }
-
-    private fun addDependencies(types: TypeSystem.Builder) {
-        val dependencies = select(ProtobufDependency::class.java).all()
-        for (d in dependencies) {
-            types.addFrom(d.file)
+            generateRejections(it)
         }
     }
 
     private fun findRejectionFiles(): List<ProtobufSourceFile> {
-        val result = select(ProtobufSourceFile::class.java)
-            .all()
+        val result = select(ProtobufSourceFile::class.java).all()
             .filter { it.isRejections() }
+
         result.forEach { it.checkConventions() }
 
         logger.atDebug().log {
@@ -103,17 +91,13 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
         return result
     }
 
-    private fun generateRejection(protoFile: ProtobufSourceFile) {
+    private fun generateRejections(protoFile: ProtobufSourceFile) {
         if (protoFile.typeMap.isEmpty()) {
             logger.atWarning().log {
                 "No rejection types found in the file `${protoFile.filePath.value}`."
             }
             return
         }
-        generateRejectionsFor(protoFile)
-    }
-
-    private fun generateRejectionsFor(protoFile: ProtobufSourceFile) {
         logger.atDebug().log {
             """
             Generating rejection classes for `${protoFile.filePath.value}`.
@@ -122,7 +106,6 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
                   Output directory: `${sources.outputRoot}`.            
             """.ti()
         }
-
         protoFile.typeMap.values
             .filter { it.isTopLevel() }
             .forEach {
@@ -131,12 +114,9 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
     }
 
     private fun generateRejection(protoFile: ProtobufSourceFile, rejection: MessageType) {
-        val javaPackage = protoFile.javaPackage()
-        val spec = RThrowableCode(javaPackage, rejection, typeSystem)
-        val packageDir = sources.outputRoot.resolve(javaPackage.replace('.', '/'))
-        val fileName = rejection.name.simpleName
-        val file = packageDir.resolve("$fileName.java")
-        spec.writeToFile(file)
+        val rtCode = RThrowableCode(protoFile.javaPackage(), rejection, typeSystem)
+        val file = rejection.throwableJavaFile(protoFile)
+        rtCode.writeToFile(file)
 
         logger.atDebug().log {
             val nl = System.lineSeparator()
@@ -146,16 +126,35 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
         }
     }
 
+    /**
+     * Obtains a name of the Java file corresponding to this [rejection message][MessageType] type.
+     *
+     * @param protoFile
+     *         the file which declares this rejection type. Serves for calculating the Java package.
+     */
+    private fun MessageType.throwableJavaFile(protoFile: ProtobufSourceFile): Path {
+        val javaPackage = protoFile.javaPackage()
+        val packageDir = sources.outputRoot.resolve(javaPackage.replace('.', '/'))
+        val file = packageDir.resolve("${name.simpleName}.java")
+        return file
+    }
+
     private fun RThrowableCode.writeToFile(file: Path) {
         val typeSpec = toPoet()
-        val indent = Indent.of4()
         val javaFile = JavaFile.builder(packageName, typeSpec)
             .skipJavaLangImports(true)
-            .indent(indent.toString())
+            .indent(INDENT)
             .build()
         val appendable = StringBuilder()
         javaFile.writeTo(appendable)
         sources.createFile(file, appendable.toString())
+    }
+
+    private companion object {
+        /**
+         * The indentation used in the generated Java code.
+         */
+        const val INDENT: String = "    "
     }
 }
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
@@ -38,6 +38,7 @@ import io.spine.protodata.ProtobufSourceFile
 import io.spine.protodata.codegen.java.JavaRenderer
 import io.spine.protodata.qualifiedName
 import io.spine.protodata.renderer.SourceFileSet
+import io.spine.string.Indent.Companion.defaultJavaIndent
 import io.spine.string.ti
 import java.nio.file.Path
 
@@ -143,18 +144,11 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
         val typeSpec = toPoet()
         val javaFile = JavaFile.builder(javaPackage, typeSpec)
             .skipJavaLangImports(true)
-            .indent(INDENT)
+            .indent(defaultJavaIndent.value)
             .build()
         val appendable = StringBuilder()
         javaFile.writeTo(appendable)
         sources.createFile(file, appendable.toString())
-    }
-
-    private companion object {
-        /**
-         * The indentation used in the generated Java code.
-         */
-        const val INDENT: String = "    "
     }
 }
 

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
@@ -132,7 +132,7 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
 
     private fun generateRejection(protoFile: ProtobufSourceFile, rejection: MessageType) {
         val javaPackage = protoFile.javaPackage()
-        val spec = KRThrowableSpec(javaPackage, rejection, typeSystem)
+        val spec = RThrowableCode(javaPackage, rejection, typeSystem)
         val packageDir = sources.outputRoot.resolve(javaPackage.replace('.', '/'))
         val fileName = rejection.name.simpleName
         val file = packageDir.resolve("$fileName.java")
@@ -146,7 +146,7 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
         }
     }
 
-    private fun KRThrowableSpec.writeToFile(file: Path) {
+    private fun RThrowableCode.writeToFile(file: Path) {
         val typeSpec = toPoet()
         val indent = Indent.of4()
         val javaFile = JavaFile.builder(packageName, typeSpec)

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RejectionRenderer.kt
@@ -141,7 +141,7 @@ public class RejectionRenderer: JavaRenderer(), WithLogging {
 
     private fun RThrowableCode.writeToFile(file: Path) {
         val typeSpec = toPoet()
-        val javaFile = JavaFile.builder(packageName, typeSpec)
+        val javaFile = JavaFile.builder(javaPackage, typeSpec)
             .skipJavaLangImports(true)
             .indent(INDENT)
             .build()

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RoasterExts.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/RoasterExts.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.mc.java.rejection
+
+import org.jboss.forge.roaster.model.JavaDoc
+
+/**
+ * Obtains the full text of the Javadoc and normalizes it.
+ *
+ * This extension function should be used instead of [JavaDoc.getFullText] to avoid
+ * issues with extra spaces that implementers of the `JavaDoc` interface may add.
+ *
+ * The following actions are performed:
+ *  1. All double spaces are replaced with single spaces.
+ *  2. All `} .` are replaced with `}.`.
+ */
+public fun JavaDoc<*>.fullTextNormalized(): String {
+    val normalized = fullText
+        .replace("  ", " ")
+        .replace("} .", "}.")
+    return normalized
+}

--- a/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/TypeSystem.kt
+++ b/mc-java-rejection/src/main/kotlin/io/spine/tools/mc/java/rejection/TypeSystem.kt
@@ -64,6 +64,17 @@ import io.spine.type.KnownTypes
 import kotlin.reflect.KClass
 
 /**
+ * Configures and builds a TypeSystem object.
+ *
+ * @param action an action for configuring the `TypeSystem` properties.
+ */
+public fun typeSystem(action: TypeSystem.Builder.() -> Unit): TypeSystem {
+    val builder = TypeSystem.newBuilder()
+    builder.action()
+    return builder.build()
+}
+
+/**
  * A type system of an application.
  *
  * Includes all the types known to the app at runtime.
@@ -164,14 +175,6 @@ private fun unknownType(type: Type): Nothing =
 
 private fun unknownType(typeName: TypeName): Nothing =
     error("Unknown type: `${typeName.typeUrl}`.")
-
-/**
- * Obtains a name of the class which corresponds to this primitive type.
- */
-internal fun PrimitiveType.toClass(): ClassName {
-    val klass = primitiveClass()
-    return ClassName(klass.javaObjectType)
-}
 
 /**
  * Obtains a name of the class which corresponds to this primitive type.

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -29,7 +29,6 @@ package io.spine.tools.mc.java.rejection
 import io.spine.code.java.PackageName
 import io.spine.code.proto.FieldName
 import io.spine.tools.div
-import io.spine.tools.fs.DirectoryName
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.fs.DirectoryName.java
 import io.spine.tools.fs.DirectoryName.main
@@ -38,9 +37,16 @@ import io.spine.tools.java.fs.toDirectory
 import java.nio.file.Path
 import kotlin.io.path.div
 
-internal object TestEnv {
+/**
+ * The environment for the integration tests checking Javadocs in
+ * the generated rejections code.
+ *
+ * @see RejectionJavadocIgTest
+ */
+internal object JavadocTestEnv {
 
     private val JAVA_PACKAGE = PackageName.of("io.spine.sample.rejections")
+    private const val PROTO_PACKAGE = "spine.sample.rejections"
     private const val TYPE_COMMENT = "The rejection definition to test Javadoc generation."
     private const val REJECTION_NAME = "Rejection"
     private const val FIRST_FIELD_COMMENT = "The rejection ID."
@@ -73,8 +79,8 @@ internal object TestEnv {
 
     fun expectedClassComment(): String = (
             wrappedInPreTag(TYPE_COMMENT)
-            + " Rejection based on proto type  " +
-            "{@code $JAVA_PACKAGE.$REJECTION_NAME}"
+            + " <p>The rejection message proto type is " +
+            " {@code $PROTO_PACKAGE.$REJECTION_NAME}"
         )
 
     fun expectedBuilderClassComment() =

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -81,7 +81,7 @@ internal object JavadocTestEnv {
     fun expectedClassComment(): String = (
             wrappedInPreTag(TYPE_COMMENT)
             + " <p>The rejection message proto type is "
-            + " {@code $PROTO_PACKAGE.$REJECTION_NAME}"
+            + " {@code $PROTO_PACKAGE.$REJECTION_NAME} ."
         )
 
     fun expectedBuilderClassComment() =

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -33,6 +33,8 @@ import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.fs.DirectoryName.java
 import io.spine.tools.fs.DirectoryName.main
 import io.spine.tools.java.fs.toDirectory
+import io.spine.tools.mc.java.rejection.Javadoc.BUILDER_ABSTRACT_TEMPLATE
+import io.spine.tools.mc.java.rejection.Javadoc.PROTO_MESSAGE_NOTE_TEMPLATE
 import java.io.File
 import kotlin.io.path.div
 
@@ -84,14 +86,12 @@ internal object JavadocTestEnv {
         return filePath.toFile()
     }
 
-    fun expectedClassComment(): String = (
-            wrappedInPreTag(TYPE_COMMENT)
-            + " <p>The rejection message proto type is "
-            + "{@code $PROTO_PACKAGE.$REJECTION_NAME}."
-        )
-
+    fun expectedClassComment(): String =
+        wrappedInPreTag(TYPE_COMMENT) +
+                PROTO_MESSAGE_NOTE_TEMPLATE.replace("\$L.\$L", "$PROTO_PACKAGE.$REJECTION_NAME")
+    
     fun expectedBuilderClassComment() =
-        "The builder for the {@code $REJECTION_NAME} rejection."
+        BUILDER_ABSTRACT_TEMPLATE.replace("\$L", REJECTION_NAME)
 
     fun expectedFirstFieldComment(): String =
         wrappedInPreTag(FIRST_FIELD_COMMENT)

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -87,7 +87,7 @@ internal object JavadocTestEnv {
     }
 
     fun expectedClassComment(): String =
-        wrappedInPreTag(TYPE_COMMENT) +
+        wrappedInPreTag(TYPE_COMMENT) + " " +
                 PROTO_MESSAGE_NOTE_TEMPLATE.replace("\$L.\$L", "$PROTO_PACKAGE.$REJECTION_NAME")
     
     fun expectedBuilderClassComment() =

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -33,12 +33,16 @@ import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.fs.DirectoryName.java
 import io.spine.tools.fs.DirectoryName.main
 import io.spine.tools.java.fs.toDirectory
-import java.nio.file.Path
+import java.io.File
 import kotlin.io.path.div
 
 /**
  * The environment for the integration tests checking Javadocs in
  * the generated rejections code.
+ *
+ * This object provides methods for checking the Javadoc comments in the generated code that
+ * provide values assuming that the text is obtained via
+ * the [org.jboss.forge.roaster.model.JavaDoc.getFullText] method.
  *
  * @see RejectionJavadocIgTest
  */
@@ -73,19 +77,21 @@ internal object JavadocTestEnv {
        }     
        """.ti().lines()
 
-    fun rejectionJavaFile(projectDir: Path): Path {
+    fun rejectionJavaFile(projectDir: File): File {
         val javaPackage = PackageName.of(JAVA_PACKAGE).toDirectory()
-        return projectDir / generated / main / java / javaPackage / "$REJECTION_NAME.java"
+        val filePath =
+            projectDir.toPath() / generated / main / java / javaPackage / "$REJECTION_NAME.java"
+        return filePath.toFile()
     }
 
     fun expectedClassComment(): String = (
             wrappedInPreTag(TYPE_COMMENT)
             + " <p>The rejection message proto type is "
-            + " {@code $PROTO_PACKAGE.$REJECTION_NAME} ."
+            + "{@code $PROTO_PACKAGE.$REJECTION_NAME}."
         )
 
     fun expectedBuilderClassComment() =
-        "The builder for the  {@code $REJECTION_NAME}  rejection."
+        "The builder for the {@code $REJECTION_NAME} rejection."
 
     fun expectedFirstFieldComment(): String =
         wrappedInPreTag(FIRST_FIELD_COMMENT)

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -73,7 +73,7 @@ internal object JavadocTestEnv {
        }     
        """.ti().lines()
 
-    fun rejectionsJavadocThrowableSource(projectDir: Path): Path {
+    fun rejectionJavaFile(projectDir: Path): Path {
         val javaPackage = PackageName.of(JAVA_PACKAGE).toDirectory()
         return projectDir / generated / main / java / javaPackage / "$REJECTION_NAME.java"
     }

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/JavadocTestEnv.kt
@@ -27,12 +27,11 @@
 package io.spine.tools.mc.java.rejection
 
 import io.spine.code.java.PackageName
-import io.spine.code.proto.FieldName
+import io.spine.string.ti
 import io.spine.tools.div
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.fs.DirectoryName.java
 import io.spine.tools.fs.DirectoryName.main
-import io.spine.tools.java.fs.FileName
 import io.spine.tools.java.fs.toDirectory
 import java.nio.file.Path
 import kotlin.io.path.div
@@ -45,42 +44,44 @@ import kotlin.io.path.div
  */
 internal object JavadocTestEnv {
 
-    private val JAVA_PACKAGE = PackageName.of("io.spine.sample.rejections")
+    private const val JAVA_PACKAGE = "io.spine.sample.rejections"
     private const val PROTO_PACKAGE = "spine.sample.rejections"
     private const val TYPE_COMMENT = "The rejection definition to test Javadoc generation."
     private const val REJECTION_NAME = "Rejection"
     private const val FIRST_FIELD_COMMENT = "The rejection ID."
-    private val FIRST_FIELD = FieldName.of("id")
+    private const val FIRST_FIELD = "id"
     private const val SECOND_FIELD_COMMENT = "The rejection message."
-    private val SECOND_FIELD = FieldName.of("rejection_message")
-    private val REJECTION_FILE_NAME = FileName.forType(REJECTION_NAME)
+    private const val SECOND_FIELD = "rejection_message"
+
+    fun rejectionFileContent(): List<String> =
+       """
+       syntax = "proto3";
+       package $PROTO_PACKAGE;
+       option java_package = "$JAVA_PACKAGE";
+       option java_multiple_files = false;
+       
+       // $TYPE_COMMENT
+       message $REJECTION_NAME {
+       
+           // $FIRST_FIELD_COMMENT
+           int32 $FIRST_FIELD = 1; // Is not a part of Javadoc.
+            
+           // $SECOND_FIELD_COMMENT
+           string $SECOND_FIELD = 2;
+           
+           bool hasNoComment = 3;
+       }     
+       """.ti().lines()
 
     fun rejectionsJavadocThrowableSource(projectDir: Path): Path {
-        val javaPackage = JAVA_PACKAGE.toDirectory()
-        return projectDir / generated / main / java / javaPackage / REJECTION_FILE_NAME.value()
-    }
-
-    fun rejectionFileContent(): Iterable<String> {
-        return listOf(
-            "syntax = \"proto3\";",
-            "package spine.sample.rejections;",
-            "option java_package = \"$JAVA_PACKAGE\";",
-            "option java_multiple_files = false;",
-            "// $TYPE_COMMENT",
-            "message $REJECTION_NAME {",
-            "    // $FIRST_FIELD_COMMENT",
-            "    int32 $FIRST_FIELD = 1; // Is not a part of Javadoc.",
-            "    // $SECOND_FIELD_COMMENT",
-            "    string $SECOND_FIELD = 2;",
-            "    bool hasNoComment = 3;",
-            "}"
-        )
+        val javaPackage = PackageName.of(JAVA_PACKAGE).toDirectory()
+        return projectDir / generated / main / java / javaPackage / "$REJECTION_NAME.java"
     }
 
     fun expectedClassComment(): String = (
             wrappedInPreTag(TYPE_COMMENT)
-            + " <p>The rejection message proto type is " +
-            " {@code $PROTO_PACKAGE.$REJECTION_NAME}"
+            + " <p>The rejection message proto type is "
+            + " {@code $PROTO_PACKAGE.$REJECTION_NAME}"
         )
 
     fun expectedBuilderClassComment() =

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionCodegenIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionCodegenIgTest.kt
@@ -47,12 +47,37 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+/**
+ * Tests the code generation of rejections.
+ *
+ * The test project is located in `rejection-codegen-test` directory in the test resources.
+ * Static initialization of the test class copies the project to a temporary directory and
+ * configures Gradle to run the code generation task by executing the [compileTestJava] task,
+ * which depends on code generation tasks.
+ *
+ * Running Java compilation ensures that:
+ *  1. The code generation is executed for both `main` and `test` source sets.
+ *  2. The generated code is compiled.
+ *
+ * Test methods of this test suite check the presence of the generated code in
+ * the expected locations.
+ *
+ * The content of the generated code is partially tested in [RejectionJavadocIgTest] suite
+ * dedicated to checking the correctness of Javadoc comments.
+ *
+ * @see RejectionJavadocIgTest
+ */
 @SlowTest
 @DisplayName("Code generation of rejections should")
 internal class RejectionCodegenIgTest {
 
     companion object {
 
+        /**
+         * The directory where the generated code is expected to be located.
+         */
+        private const val PACKAGE_DIR = "io/spine/sample/rejections"
+        
         private lateinit var moduleDir: File
 
         @BeforeAll
@@ -127,7 +152,7 @@ internal class RejectionCodegenIgTest {
         @Test
         fun `for 'main' source set`() {
             // As defined in `resources/.../main_rejections.proto`.
-            val packageDir = targetMainDir().resolve(java).resolve("io/spine/sample/rejections")
+            val packageDir = targetMainDir().resolve(java).resolve(PACKAGE_DIR)
             assertExists(packageDir)
 
             // As defined in `resources/.../main_rejections.proto`.
@@ -142,7 +167,7 @@ internal class RejectionCodegenIgTest {
         @Test
         fun `for 'test' source set`() {
             // As defined in `resources/.../test_rejections.proto`.
-            val packageDir = targetTestDir().resolve(java).resolve("io/spine/sample/rejections")
+            val packageDir = targetTestDir().resolve(java).resolve(PACKAGE_DIR)
             assertExists(packageDir)
 
             // As defined in `resources/.../test_rejections.proto`.

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionCodegenIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionCodegenIgTest.kt
@@ -27,6 +27,7 @@
 package io.spine.tools.mc.java.rejection
 
 import io.kotest.matchers.shouldBe
+import io.spine.testing.SlowTest
 import io.spine.testing.TempDir
 import io.spine.tools.code.SourceSetName
 import io.spine.tools.code.SourceSetName.Companion.main
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+@SlowTest
 @DisplayName("Code generation of rejections should")
 internal class RejectionCodegenIgTest {
 

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -69,7 +69,7 @@ internal class RejectionJavadocIgTest {
                 .addFile("src/main/proto/javadoc_rejections.proto", rejectionFileContent())
                 .create()
             project.executeTask(launchProtoData)
-            val generatedFile = rejectionJavaFile(projectDir.toPath()).toFile()
+            val generatedFile = rejectionJavaFile(projectDir)
             generatedSource = Roaster.parse(
                 JavaClassSource::class.java, generatedFile
             )
@@ -107,7 +107,7 @@ internal class RejectionJavadocIgTest {
 
 private fun assertDoc(expectedText: String, source: JavaDocCapableSource<*>) {
     val javadoc = source.javaDoc
-    javadoc.fullText shouldBe expectedText
+    javadoc.fullTextNormalized() shouldBe expectedText
 }
 
 private fun assertMethodDoc(

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -57,6 +57,7 @@ internal class RejectionJavadocIgTest {
     companion object {
 
         private lateinit var generatedSource: JavaClassSource
+        private lateinit var builderType: JavaClassSource
 
         @BeforeAll
         @JvmStatic
@@ -72,23 +73,33 @@ internal class RejectionJavadocIgTest {
             generatedSource = Roaster.parse(
                 JavaClassSource::class.java, generatedFile
             )
+            val builderTypeName = SimpleClassName.ofBuilder().value
+            builderType = generatedSource.getNestedType(builderTypeName) as JavaClassSource
         }
     }
 
     @Test
-    fun `rejection type`() {
+    fun `'RejectionThrowable' class`() {
         assertDoc(expectedClassComment(), generatedSource)
+    }
+
+    @Test
+    fun `'newBuilder' method`() {
         assertMethodDoc(NEW_BUILDER_METHOD_ABSTRACT, generatedSource, NEW_BUILDER)
     }
 
     @Test
-    fun `'Builder' of rejection`() {
-        val builderTypeName = SimpleClassName.ofBuilder().value()
-        val builderType = generatedSource.getNestedType(builderTypeName) as JavaClassSource
-
+    fun `'Builder' class under the 'RejectionThrowable'`() {
         assertDoc(expectedBuilderClassComment(), builderType)
+    }
 
+    @Test
+    fun `'build()' method of the 'Builder' class`() {
         assertMethodDoc(BUILD_METHOD_ABSTRACT, builderType, BUILD)
+    }
+
+    @Test
+    fun `property setters of the builder`() {
         assertMethodDoc(expectedFirstFieldComment(), builderType, "setId")
         assertMethodDoc(expectedSecondFieldComment(), builderType, "setRejectionMessage")
     }

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -104,17 +104,13 @@ private fun assertMethodDoc(
     source: JavaClassSource,
     methodName: String
 ) {
-    val method = findMethod(source, methodName)
+    val method = source.findMethod(methodName)
     assertDoc(expectedComment, method)
 }
 
-private fun findMethod(
-    source: JavaClassSource,
-    methodName: String
-): MethodSource<JavaClassSource> {
-    return source.methods.stream()
-        .filter { m -> methodName == m.name }
+private fun JavaClassSource.findMethod(methodName: String): MethodSource<JavaClassSource> =
+    methods.stream()
+        .filter { methodName == it.name }
         .findFirst()
         .orElseThrow { error("Cannot find the method `$methodName`.") }
-}
 

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -124,4 +124,3 @@ private fun JavaClassSource.findMethod(methodName: String): MethodSource<JavaCla
         .filter { methodName == it.name }
         .findFirst()
         .orElseThrow { error("Cannot find the method `$methodName`.") }
-

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 @SlowTest
-@DisplayName("Rejection code generator should generate Javadoc for")
+@DisplayName("Rejection code generator should produce Javadoc for")
 internal class RejectionJavadocIgTest {
 
     companion object {

--- a/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
+++ b/mc-java-rejection/src/test/kotlin/io/spine/tools/mc/java/rejection/RejectionJavadocIgTest.kt
@@ -31,15 +31,17 @@ import io.spine.code.java.SimpleClassName
 import io.spine.testing.SlowTest
 import io.spine.testing.TempDir
 import io.spine.tools.gradle.testing.GradleProject.Companion.setupAt
-import io.spine.tools.java.code.BuilderSpec.BUILD_METHOD_NAME
 import io.spine.tools.mc.java.gradle.McJavaTaskName.Companion.launchProtoData
-import io.spine.tools.mc.java.rejection.RThrowableBuilderCode.Companion.NEW_BUILDER_METHOD_NAME
 import io.spine.tools.mc.java.rejection.JavadocTestEnv.expectedBuilderClassComment
 import io.spine.tools.mc.java.rejection.JavadocTestEnv.expectedClassComment
 import io.spine.tools.mc.java.rejection.JavadocTestEnv.expectedFirstFieldComment
 import io.spine.tools.mc.java.rejection.JavadocTestEnv.expectedSecondFieldComment
 import io.spine.tools.mc.java.rejection.JavadocTestEnv.rejectionFileContent
-import io.spine.tools.mc.java.rejection.JavadocTestEnv.rejectionsJavadocThrowableSource
+import io.spine.tools.mc.java.rejection.JavadocTestEnv.rejectionJavaFile
+import io.spine.tools.mc.java.rejection.Javadoc.BUILD_METHOD_ABSTRACT
+import io.spine.tools.mc.java.rejection.Javadoc.NEW_BUILDER_METHOD_ABSTRACT
+import io.spine.tools.mc.java.rejection.Method.BUILD
+import io.spine.tools.mc.java.rejection.Method.NEW_BUILDER
 import org.jboss.forge.roaster.Roaster
 import org.jboss.forge.roaster.model.source.JavaClassSource
 import org.jboss.forge.roaster.model.source.JavaDocCapableSource
@@ -66,7 +68,7 @@ internal class RejectionJavadocIgTest {
                 .addFile("src/main/proto/javadoc_rejections.proto", rejectionFileContent())
                 .create()
             project.executeTask(launchProtoData)
-            val generatedFile = rejectionsJavadocThrowableSource(projectDir.toPath()).toFile()
+            val generatedFile = rejectionJavaFile(projectDir.toPath()).toFile()
             generatedSource = Roaster.parse(
                 JavaClassSource::class.java, generatedFile
             )
@@ -76,10 +78,7 @@ internal class RejectionJavadocIgTest {
     @Test
     fun `rejection type`() {
         assertDoc(expectedClassComment(), generatedSource)
-        assertMethodDoc(
-            "@return a new builder for the rejection", generatedSource,
-            NEW_BUILDER_METHOD_NAME
-        )
+        assertMethodDoc(NEW_BUILDER_METHOD_ABSTRACT, generatedSource, NEW_BUILDER)
     }
 
     @Test
@@ -89,10 +88,7 @@ internal class RejectionJavadocIgTest {
 
         assertDoc(expectedBuilderClassComment(), builderType)
 
-        assertMethodDoc(
-            "Creates the rejection from the builder and validates it.", builderType,
-            BUILD_METHOD_NAME
-        )
+        assertMethodDoc(BUILD_METHOD_ABSTRACT, builderType, BUILD)
         assertMethodDoc(expectedFirstFieldComment(), builderType, "setId")
         assertMethodDoc(expectedSecondFieldComment(), builderType, "setRejectionMessage")
     }

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -56,6 +56,8 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
     private static final String PROTO_DATA_ID = "io.spine.protodata";
     private static final String CONFIG_SUBDIR = "protodata-config";
 
+    @SuppressWarnings("DuplicateStringLiteralInspection")
+        // Could be duplicated in auto-generated Gradle code via script plugins in `buildSrc`.
     private static final String PROTODATA_CONFIGURATION = "protoData";
     private static final String IMPL_CONFIGURATION = "implementation";
 

--- a/mc-java/src/main/kotlin/io/spine/tools/mc/java/gradle/Artifacts.kt
+++ b/mc-java/src/main/kotlin/io/spine/tools/mc/java/gradle/Artifacts.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,7 +134,6 @@ private val validationVersion: String by lazy {
 /**
  * The Maven artifact containing the `spine-validation-java-extensions` module.
  */
-@Suppress("FunctionOnlyReturningConstant") // make detekt happy about the `getName()`
 @get:JvmName("validationJavaBundle")
 internal val validationJavaBundle: Artifact by lazy {
     artifact {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.160</version>
+<version>2.0.0-SNAPSHOT.161</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,5 +32,5 @@
  * For versions of Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  * Keep in mind that changing it under `buildSrc` also requires sync. with `tests/buildSrc`.
  */
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.160")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.161")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This PR continues improvement of code generation for  classes implementing`RejectionThrowable`. In particular:
  * Code related to generation of Javadoc comments was consolidated under the `io.spine.tools.mc.java.rejection.Javadoc` object.
  * The class `KRThrowableSpec.kt` was renamed to `RThorwableCode`, and `KRThrowableBuilderSpec` was renamed to `RThrowableBuilderCode`.
  * Extension functions for working with JavaPoet and Roaster were introduced. Later this code is going to be promoted to be a part of `tool-base.
  * Test data for verifying Javadoc generation was consolidated with strings and templates now residing in `Javadoc` object.
  * Javadoc test suite was improve to have test functions each testing one aspect of the generated code.
