### PR TITLE
Use existing dependencies for other configurations

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.183"
+        const val toolBase = "2.0.0-SNAPSHOT.184"
 
         /**
          * The version of [Spine.javadocTools].

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
@@ -912,12 +912,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:16 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -1698,12 +1698,12 @@ This report was generated on **Wed Aug 30 19:30:23 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:23 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:16 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -2484,12 +2484,12 @@ This report was generated on **Wed Aug 30 19:30:23 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:16 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
@@ -3187,12 +3187,12 @@ This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:17 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
@@ -4070,12 +4070,12 @@ This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:17 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-protoc:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -4848,12 +4848,12 @@ This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:17 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-protodata-params:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -5588,12 +5588,12 @@ This report was generated on **Wed Aug 30 19:30:24 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:17 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-rejection:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -6366,12 +6366,12 @@ This report was generated on **Wed Aug 30 19:30:25 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:18 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.169`
+# Dependencies of `io.spine.tools:spine-mc-java-validation:2.0.0-SNAPSHOT.170`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
@@ -7144,4 +7144,4 @@ This report was generated on **Wed Aug 30 19:30:25 WEST 2023** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 30 19:30:25 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Sep 03 23:50:18 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
+++ b/mc-java/src/main/java/io/spine/tools/mc/java/gradle/plugins/ProtoDataConfigPlugin.java
@@ -29,8 +29,11 @@ package io.spine.tools.mc.java.gradle.plugins;
 import com.google.common.collect.ImmutableList;
 import io.spine.protodata.gradle.CodegenSettings;
 import io.spine.protodata.gradle.plugin.LaunchProtoData;
+import io.spine.tools.gradle.Artifact;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
 
 import static io.spine.tools.fs.DirectoryName.kotlin;
 import static io.spine.tools.mc.java.gradle.Artifacts.mcJavaAnnotation;
@@ -83,7 +86,7 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
     }
 
     private static void configureProtoData(Project target) {
-        configureRenderers(target);
+        configurePlugins(target);
 
         var tasks = target.getTasks();
         tasks.withType(LaunchProtoData.class, task -> {
@@ -98,15 +101,34 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
         });
     }
 
+    private static void addDependency(
+            Project project,
+            String configurationName,
+            Artifact artifact
+    ) {
+        var dependencies = project.getDependencies();
+        var dependency = findDependency(project, artifact);
+        if (dependency == null) {
+            dependencies.add(configurationName, artifact.notation());
+        } else {
+            dependencies.add(configurationName, dependency);
+        }
+    }
+
+    private static void addDependencies(
+            Project project,
+            String configurationName,
+            Artifact... artifacts
+    ) {
+        for (var artifact : artifacts) {
+            addDependency(project, configurationName, artifact);
+        }
+    }
+
     /**
-     * Configures ProtoData with the renderers and plugins,
-     * for the passed Gradle project.
-     *
-     * <p>In case the Validation
-     * {@linkplain io.spine.tools.mc.java.gradle.codegen.ValidationConfig#shouldSkipValidation()
-     * is disabled}, its renderers and the plugin are not added.
+     * Configures ProtoData with the renderers and plugins, for the passed Gradle project.
      */
-    private static void configureRenderers(Project project) {
+    private static void configurePlugins(Project project) {
         var codegen = project.getExtensions()
                              .getByType(CodegenSettings.class);
 
@@ -122,12 +144,13 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
                 kotlin.value()
         ));
 
-        var dependencies = project.getDependencies();
-
-        dependencies.add(PROTODATA_CONFIGURATION, mcJavaBase().notation());
-        dependencies.add(PROTODATA_CONFIGURATION, mcJavaAnnotation().notation());
-        dependencies.add(PROTODATA_CONFIGURATION, mcJavaRejection().notation());
-        dependencies.add(PROTODATA_CONFIGURATION, toolBase().notation());
+        addDependencies(
+                project, PROTODATA_CONFIGURATION,
+                mcJavaBase(),
+                mcJavaAnnotation(),
+                mcJavaRejection(),
+                toolBase()
+        );
     }
 
     private static void configureValidationRendering(Project project, CodegenSettings codegen) {
@@ -139,9 +162,8 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
                 "io.spine.validation.java.JavaValidationPlugin"
         );
 
-        var dependencies = project.getDependencies();
-        dependencies.add(PROTODATA_CONFIGURATION, validationJavaBundle().notation());
-        dependencies.add(IMPL_CONFIGURATION, validationJavaRuntime().notation());
+        addDependency(project, PROTODATA_CONFIGURATION, validationJavaBundle());
+        addDependency(project, IMPL_CONFIGURATION, validationJavaRuntime());
     }
 
     private static
@@ -154,5 +176,17 @@ final class ProtoDataConfigPlugin implements Plugin<Project> {
         targetFile.convention(defaultFile);
         task.getConfigurationFile()
             .set(targetFile);
+    }
+
+    private static @Nullable Dependency findDependency(Project project, Artifact artifact) {
+        var dependencies = project.getConfigurations().stream()
+                .flatMap(c -> c.getDependencies().stream());
+
+        var found = dependencies.filter((d) ->
+            d.getGroup() != null
+                    && d.getGroup().equals(artifact.group())
+                    && d.getName().equals(artifact.name())
+        ).findFirst().orElse(null);
+        return found;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.169</version>
+<version>2.0.0-SNAPSHOT.170</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -98,7 +98,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.183</version>
+    <version>2.0.0-SNAPSHOT.184</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -176,7 +176,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.183</version>
+    <version>2.0.0-SNAPSHOT.184</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -188,7 +188,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.183</version>
+    <version>2.0.0-SNAPSHOT.184</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,5 +31,5 @@
  *
  * For versions of Spine-based dependencies please see [io.spine.internal.dependency.Spine].
  */
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.169")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.170")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This PR teaches McJava to use existing dependencies for other configurations. Previously, the dependencies were added using versions from the resources. Sometimes it is not convenient, especially when breaking API changes are introduced.