### PR TITLE
Fix integration with Gradle in `KspBasedPlugin`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1129,7 +1129,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2070,7 +2070,7 @@ This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3019,7 +3019,7 @@ This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3855,7 +3855,7 @@ This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4796,7 +4796,7 @@ This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5603,7 +5603,7 @@ This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6544,7 +6544,7 @@ This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7351,7 +7351,7 @@ This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8343,7 +8343,7 @@ This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9292,7 +9292,7 @@ This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11048,7 +11048,7 @@ This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11855,7 +11855,7 @@ This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12900,7 +12900,7 @@ This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13968,7 +13968,7 @@ This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14824,7 +14824,7 @@ This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -15773,7 +15773,7 @@ This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -16580,7 +16580,7 @@ This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -17529,7 +17529,7 @@ This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -18336,4 +18336,4 @@ This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1129,7 +1129,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2070,7 +2070,7 @@ This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3019,7 +3019,7 @@ This report was generated on **Mon Mar 17 18:12:25 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:41 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3855,7 +3855,7 @@ This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4796,7 +4796,7 @@ This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5603,7 +5603,7 @@ This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -6544,7 +6544,7 @@ This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:42 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7351,7 +7351,7 @@ This report was generated on **Mon Mar 17 18:12:26 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8343,7 +8343,7 @@ This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9292,7 +9292,7 @@ This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -10099,7 +10099,7 @@ This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11048,7 +11048,7 @@ This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:43 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11855,7 +11855,7 @@ This report was generated on **Mon Mar 17 18:12:27 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:44 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -12900,7 +12900,7 @@ This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:44 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -13968,7 +13968,7 @@ This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:44 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -14824,7 +14824,7 @@ This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:44 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -15773,7 +15773,7 @@ This report was generated on **Mon Mar 17 18:12:28 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:45 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -16580,7 +16580,7 @@ This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:45 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -17529,7 +17529,7 @@ This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:45 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -18336,4 +18336,4 @@ This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Mar 17 18:12:29 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Mar 18 17:57:45 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -1129,12 +1129,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-annotation:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -2070,12 +2070,12 @@ This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:05 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-base:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -3019,12 +3019,12 @@ This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-checks:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.github.ben-manes.caffeine. **Name** : caffeine. **Version** : 3.0.5.
@@ -3855,12 +3855,12 @@ This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-comparable:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-comparable:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -4796,12 +4796,12 @@ This report was generated on **Sun Mar 16 21:14:58 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-comparable-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-comparable-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -5603,12 +5603,12 @@ This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-entity:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-entity:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -6544,12 +6544,12 @@ This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-entity-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-entity-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -7351,12 +7351,12 @@ This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-ksp:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-ksp:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -8343,12 +8343,12 @@ This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-marker:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-marker:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -9292,12 +9292,12 @@ This report was generated on **Sun Mar 16 21:14:59 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:07 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-marker-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-marker-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -10099,12 +10099,12 @@ This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-message-group:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-message-group:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -11048,12 +11048,12 @@ This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-message-group-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-message-group-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -11855,12 +11855,12 @@ This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-plugin-bundle:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -12900,12 +12900,12 @@ This report was generated on **Sun Mar 16 21:15:00 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-routing:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-routing:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -13968,12 +13968,12 @@ This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:08 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-routing-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-routing-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14824,12 +14824,12 @@ This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-signal:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-signal:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -15773,12 +15773,12 @@ This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-signal-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-signal-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -16580,12 +16580,12 @@ This report was generated on **Sun Mar 16 21:15:01 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-uuid:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-uuid:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.3.
@@ -17529,12 +17529,12 @@ This report was generated on **Sun Mar 16 21:15:02 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-mc-java-uuid-tests:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine.tools:spine-mc-java-uuid-tests:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -18336,4 +18336,4 @@ This report was generated on **Sun Mar 16 21:15:02 WET 2025** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 16 21:15:02 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 17 17:54:09 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
@@ -52,7 +52,7 @@ import org.gradle.kotlin.dsl.findByType
  *
  * The plugin performs the following configuration steps:
  *
- *  1. Adds the [KSP Gradle Plugin](https://github.com/google/ksp) to the project,
+ *  1. Adds the [KSP Gradle Plugin](https://github.com/google/ksp) to the project
  *     if it is not added already.
  *
  *  2. Makes a KSP task depend on a `LaunchProtoData` task for the same source set.
@@ -127,7 +127,7 @@ public abstract class KspBasedPlugin : Plugin<Project> {
         private const val configurationNamePrefix: String = "ksp"
 
         /**
-         * The Manen coordinates of Google Auto Service annotations that
+         * The Maven coordinates of Google Auto Service annotations that
          * we [add][Project.addDependencies] as `compileOnly` dependencies to
          * the source sets of the project to which th
          */

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
@@ -34,6 +34,7 @@ import io.spine.tools.fs.DirectoryName.grpc
 import io.spine.tools.fs.DirectoryName.java
 import io.spine.tools.fs.DirectoryName.kotlin
 import io.spine.tools.gradle.project.sourceSets
+import io.spine.tools.gradle.project.sourceSet
 import io.spine.tools.gradle.protobuf.generated
 import io.spine.tools.gradle.protobuf.generatedDir
 import io.spine.tools.gradle.protobuf.generatedSourceProtoDir
@@ -200,11 +201,19 @@ private fun Project.replaceKspOutputDirs() {
     afterEvaluate {
         val underBuild = KspGradlePlugin.defaultTargetDirectory(it).toString()
         val underProject = generatedDir.toString()
-        kspTasks().forEach { (_, kspTask) ->
+        kspTasks().forEach { (ssn, kspTask) ->
             kspTask.kspConfig.run {
                 outputBaseDir.replace(underBuild, underProject)
                 kotlinOutputDir.replace(underBuild, underProject)
                 javaOutputDir.replace(underBuild, underProject)
+
+                // KSP Gradle Plugin already added its output to source sets.
+                // We need to add the replacement manually.
+                sourceSet(ssn).kotlinDirectorySet()?.run {
+                    srcDirs(kotlinOutputDir)
+                    srcDirs(javaOutputDir)
+                }
+
             }
         }
     }

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
@@ -86,6 +86,7 @@ public abstract class KspBasedPlugin : Plugin<Project> {
         synchronized(lock) {
             if (!commonSettingsApplied.contains(this)) {
                 useKsp2()
+                addDependencies()
                 excludeSourcesFromBuildDir()
                 addProtoDataGeneratedSources()
                 makeKspTasksDependOnProtoData()
@@ -103,6 +104,16 @@ public abstract class KspBasedPlugin : Plugin<Project> {
             }
     }
 
+    private fun Project.addDependencies() {
+        sourceSets.forEach { sourceSet ->
+            val configurationName = sourceSet.compileOnlyConfigurationName
+            dependencies.add(configurationName,
+                autoServiceAnnotations
+            )
+        }
+    }
+
+    @Suppress("ConstPropertyName")
     protected companion object {
 
         /**
@@ -115,6 +126,13 @@ public abstract class KspBasedPlugin : Plugin<Project> {
          */
         private const val configurationNamePrefix: String = "ksp"
 
+        /**
+         * The Manen coordinates of Google Auto Service annotations that
+         * we [add][Project.addDependencies] as `compileOnly` dependencies to
+         * the source sets of the project to which th
+         */
+        private const val autoServiceAnnotations: String =
+            "com.google.auto.service:auto-service-annotations:1.1.1"
         /**
          * Contains projects to which [KspBasedPlugin]s already applied common settings.
          */

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/gradle/KspBasedPlugin.kt
@@ -214,6 +214,9 @@ private fun Project.makeKspTasksDependOnProtoData() {
  * The function replaces default destination directory defied by
  * [com.google.devtools.ksp.gradle.KspGradleSubplugin.getKspOutputDir] to
  * the one we used for all the generated code at the level of the project root.
+ *
+ * Also `kotlin` directory set for each source set gets new generated
+ * Kotlin and Java source directories as its inputs.
  */
 private fun Project.replaceKspOutputDirs() {
     afterEvaluate {
@@ -226,12 +229,12 @@ private fun Project.replaceKspOutputDirs() {
                 javaOutputDir.replace(underBuild, underProject)
 
                 // KSP Gradle Plugin already added its output to source sets.
-                // We need to add the replacement manually.
+                // We need to add the replacement manually because we filtered
+                // it before in `Project.excludeSourcesFromBuildDir()`.
                 sourceSet(ssn).kotlinDirectorySet()?.run {
                     srcDirs(kotlinOutputDir)
                     srcDirs(javaOutputDir)
                 }
-
             }
         }
     }

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSClassDeclarationExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSClassDeclarationExts.kt
@@ -26,10 +26,16 @@
 
 package io.spine.tools.mc.java.ksp.processor
 
-import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 
 /**
- * Obtains the qualified name of this declaration or `null`
- * if the declaration does not have a qualified name.
+ * Obtains the string with the reference to this class declaration in diagnostic messages.
+ *
+ * @return The qualified name of the class, if it is available, otherwise its simple name.
+ *  The returned name is wrapped in backticks.
  */
-public fun KSDeclaration.qualified(): String? = qualifiedName?.asString()
+public val KSClassDeclaration.reference: String
+    get() {
+        val name = qualifiedName?.asString() ?: simpleName.asString()
+        return "`$name`"
+    }

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSClassDeclarationExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSClassDeclarationExts.kt
@@ -34,7 +34,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
  * @return The qualified name of the class, if it is available, otherwise its simple name.
  *  The returned name is wrapped in backticks.
  */
-public val KSClassDeclaration.reference: String
+public val KSClassDeclaration.diagRef: String
     get() {
         val name = qualifiedName?.asString() ?: simpleName.asString()
         return "`$name`"

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSDeclarationExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSDeclarationExts.kt
@@ -26,6 +26,8 @@
 
 package io.spine.tools.mc.java.ksp.processor
 
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 
 /**
@@ -33,3 +35,11 @@ import com.google.devtools.ksp.symbol.KSDeclaration
  * if the declaration does not have a qualified name.
  */
 public fun KSDeclaration.qualified(): String? = qualifiedName?.asString()
+
+public fun KSClassDeclaration.superclass(): KSClassDeclaration? {
+    val found = superTypes.find { type ->
+        val superDecl = (type.resolve().declaration as KSClassDeclaration)
+        superDecl.classKind == ClassKind.CLASS
+    }
+    return found?.resolve()?.declaration as? KSClassDeclaration
+}

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSDeclarationExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSDeclarationExts.kt
@@ -26,8 +26,6 @@
 
 package io.spine.tools.mc.java.ksp.processor
 
-import com.google.devtools.ksp.symbol.ClassKind
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 
 /**
@@ -35,11 +33,3 @@ import com.google.devtools.ksp.symbol.KSDeclaration
  * if the declaration does not have a qualified name.
  */
 public fun KSDeclaration.qualified(): String? = qualifiedName?.asString()
-
-public fun KSClassDeclaration.superclass(): KSClassDeclaration? {
-    val found = superTypes.find { type ->
-        val superDecl = (type.resolve().declaration as KSClassDeclaration)
-        superDecl.classKind == ClassKind.CLASS
-    }
-    return found?.resolve()?.declaration as? KSClassDeclaration
-}

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSFunctionDeclarationExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSFunctionDeclarationExts.kt
@@ -55,7 +55,7 @@ public fun KSFunctionDeclaration.msg(kotlin: String, java: String): String =
 /**
  * Obtains the text for referencing this function in a diagnostic message.
  */
-public val KSFunctionDeclaration.funRef: String
+public val KSFunctionDeclaration.diagRef: String
     get() {
         val shortRef = "`$shortName()`"
         return msg("function $shortRef", "method $shortRef")

--- a/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSTypeExts.kt
+++ b/mc-java-ksp/src/main/kotlin/io/spine/tools/mc/java/ksp/processor/KSTypeExts.kt
@@ -26,9 +26,12 @@
 
 package io.spine.tools.mc.java.ksp.processor
 
+import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind.INTERFACE
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.Variance
 
 /**
  * Tells if this type represents an interface.
@@ -48,3 +51,19 @@ public val KSType.ref: String
  */
 public val KSType.qualifiedRef: String
     get() = "`${declaration.qualifiedName?.asString()}`"
+
+/**
+ * Transforms this instance of [KSType] to an instance of [KSTypeArgument]
+ * using the given [resolver].
+ *
+ * @param resolver The resolver to create the type argument instance.
+ * @param variance The variance to use for the type argument.
+ *  The default value is [Variance.INVARIANT].
+ */
+public fun KSType.toTypeArgument(
+    resolver: Resolver,
+    variance: Variance = Variance.INVARIANT
+): KSTypeArgument {
+    val typeRef = resolver.createKSTypeReferenceFromKSType(this)
+    return resolver.getTypeArgument(typeRef, variance)
+}

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/CommonChecks.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/CommonChecks.kt
@@ -33,7 +33,7 @@ import com.google.devtools.ksp.symbol.Modifier.JAVA_STATIC
 import com.google.devtools.ksp.symbol.Origin.JAVA
 import com.google.devtools.ksp.symbol.Origin.KOTLIN
 import io.spine.server.entity.Entity
-import io.spine.tools.mc.java.ksp.processor.funRef
+import io.spine.tools.mc.java.ksp.processor.diagRef
 import io.spine.tools.mc.java.ksp.processor.msg
 import io.spine.tools.mc.java.routing.processor.RouteSignature.Companion.routeRef
 
@@ -65,8 +65,8 @@ private fun KSFunctionDeclaration.isStatic(logger: KSPLogger): Boolean {
     } 
     if (!isStatic) {
         logger.error(msg(
-            "The $funRef annotated with $routeRef must be a member of a companion object.",
-            "The $funRef annotated with $routeRef must be `static`."
+            "The $diagRef annotated with $routeRef must be a member of a companion object.",
+            "The $diagRef annotated with $routeRef must be `static`."
         ),
             this
         )
@@ -79,7 +79,7 @@ private fun KSFunctionDeclaration.declaredInAClass(logger: KSPLogger): Boolean {
     if (!inClass) {
         // This case is Kotlin-only because in Java a function would belong to a class.
         logger.error(
-            "The $funRef annotated with $routeRef must be" +
+            "The $diagRef annotated with $routeRef must be" +
                     " a member of a companion object of an entity class.",
             this
         )
@@ -91,7 +91,7 @@ private fun KSFunctionDeclaration.acceptsOneOrTwoParameters(logger: KSPLogger): 
     val wrongNumber = parameters.isEmpty() || parameters.size > 2
     if (wrongNumber) {
         logger.error(
-            "The $funRef annotated with $routeRef must accept one or two parameters. " +
+            "The $diagRef annotated with $routeRef must accept one or two parameters. " +
                     "Encountered: ${parameters.size}.",
             this
         )
@@ -124,7 +124,7 @@ internal fun KSFunctionDeclaration.declaringClass(environment: Environment): Ent
     val projectedType = declaringClass.asStarProjectedType()
     if (!environment.entityInterface.isAssignableFrom(projectedType)) {
         environment.logger.error(
-            "The declaring class of the $funRef annotated with $routeRef" +
+            "The declaring class of the $diagRef annotated with $routeRef" +
                     " must implement the `${Entity::class.java.canonicalName}` interface.",
             this
         )

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
@@ -31,7 +31,10 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeReference
+import io.spine.tools.mc.java.ksp.processor.reference
 import io.spine.tools.mc.java.ksp.processor.toTypeArgument
+
+
 
 /**
  * Provides information about an entity class.
@@ -59,14 +62,23 @@ internal class EntityClass(
      * The type of the entity identifiers as [KSTypeArgument].
      */
     val idClassTypeArgument: KSTypeArgument by lazy {
-        resolveEntityIdType(decl)
+        resolveIdType(decl)
     }
 
-    @Suppress("LoopWithTooManyJumpStatements", "unused")
-    private fun resolveEntityIdType(classDeclaration: KSClassDeclaration): KSTypeArgument {
-        val idGetter =
-            classDeclaration.getAllFunctions().find { it.simpleName.asString() == "id" }
-        checkNotNull(idGetter)
+    /**
+     * Obtains the type of the entity identifiers as an instance of [KSTypeArgument].
+     *
+     * The function uses the reference to the [Entity.id][ID_METHOD_NAME] function
+     * which returns the ID for resolving the type.
+     */
+    private fun resolveIdType(classDeclaration: KSClassDeclaration): KSTypeArgument {
+        val idGetter = classDeclaration.getAllFunctions().find {
+            it.simpleName.asString() == ID_METHOD_NAME
+        }
+        checkNotNull(idGetter) {
+            "Unable to find the function named `$ID_METHOD_NAME` in" +
+                    " the class `${classDeclaration.reference}`."
+        }
         val idReturnType = idGetter.returnType!!.resolve()
         return idReturnType.toTypeArgument(environment.resolver)
     }
@@ -108,4 +120,14 @@ internal class EntityClass(
      * Obtains the qualified name of the entity class.
      */
     override fun toString(): String = decl.qualifiedName!!.asString()
+
+    companion object {
+
+        /**
+         * The name of the [id][io.spine.server.entity.Entity.id] method
+         * of the [Entity][io.spine.server.entity.Entity] interface which is used
+         * for obtaining the type of the entity identifiers.
+         */
+        private const val ID_METHOD_NAME = "id"
+    }
 }

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
@@ -26,13 +26,12 @@
 
 package io.spine.tools.mc.java.routing.processor
 
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind.CLASS
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeReference
-import com.google.devtools.ksp.symbol.Variance
+import io.spine.tools.mc.java.ksp.processor.toTypeArgument
 
 /**
  * Provides information about an entity class.
@@ -61,11 +60,6 @@ internal class EntityClass(
      */
     val idClassTypeArgument: KSTypeArgument by lazy {
         resolveEntityIdType(decl)
-    }
-
-    private fun KSType.toTypeArgument(resolver: Resolver): KSTypeArgument {
-        val typeRef = resolver.createKSTypeReferenceFromKSType(this)
-        return resolver.getTypeArgument(typeRef, Variance.INVARIANT)
     }
 
     @Suppress("LoopWithTooManyJumpStatements", "unused")

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
@@ -31,7 +31,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeReference
-import io.spine.tools.mc.java.ksp.processor.reference
+import io.spine.tools.mc.java.ksp.processor.diagRef
 import io.spine.tools.mc.java.ksp.processor.toTypeArgument
 
 
@@ -77,7 +77,7 @@ internal class EntityClass(
         }
         checkNotNull(idGetter) {
             "Unable to find the function named `$ID_METHOD_NAME` in" +
-                    " the class `${classDeclaration.reference}`."
+                    " the class `${classDeclaration.diagRef}`."
         }
         val idReturnType = idGetter.returnType!!.resolve()
         return idReturnType.toTypeArgument(environment.resolver)

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/EntityClass.kt
@@ -62,13 +62,23 @@ internal class EntityClass(
      * The type of the entity identifiers as [KSTypeArgument].
      */
     val idClassTypeArgument: KSTypeArgument by lazy {
-        val asEntity = decl.superTypes.find {
-            entityInterface.isAssignableFrom(it.resolve())
+        var superType: KSType
+        var asEntity = decl.superTypes.find { type ->
+            superType = type.resolve()
+            entityInterface.isAssignableFrom(superType)
+//            val superDecl = superType.declaration
+//                    && superDecl is KSClassDeclaration
+//                    && superDecl.classKind == CLASS
         }
         check(asEntity != null) {
             "The class `${decl.qualifiedName!!.asString()}`" +
                     " must implement `${entityInterface.declaration.qualified()}`."
         }
+//        val numTypeArgs = entityInterface.arguments.size
+//        while (asEntity.element!!.typeArguments.size < numTypeArgs) {
+//            asEntity.element
+//        }
+
         asEntity.element!!.typeArguments.first()
     }
 

--- a/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/RouteSignature.kt
+++ b/mc-java-routing/src/main/kotlin/io/spine/tools/mc/java/routing/processor/RouteSignature.kt
@@ -32,7 +32,7 @@ import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper
 import io.spine.core.SignalContext
 import io.spine.server.route.Route
 import io.spine.string.simply
-import io.spine.tools.mc.java.ksp.processor.funRef
+import io.spine.tools.mc.java.ksp.processor.diagRef
 import io.spine.tools.mc.java.ksp.processor.isSame
 import io.spine.tools.mc.java.ksp.processor.toType
 import io.spine.tools.mc.java.routing.processor.RouteSignature.Companion.qualify
@@ -131,7 +131,7 @@ internal sealed class RouteSignature<F : RouteFun>(
                 // about the type of the second parameter.
                 val actualSecondParamName = secondParamType.declaration.simpleName.getShortName()
                 environment.logger.error(
-                    "The second parameter of the ${fn.funRef} annotated with $routeRef" +
+                    "The second parameter of the ${fn.diagRef} annotated with $routeRef" +
                             " must be `${contextClass.simpleName}`." +
                             " Encountered: `$actualSecondParamName`.",
                     fn

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>mc-java</artifactId>
-<version>2.0.0-SNAPSHOT.302</version>
+<version>2.0.0-SNAPSHOT.303</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,5 +31,5 @@
  *
  * For versions of Spine-based dependencies please see [io.spine.internal.dependency.spine].
  */
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.301")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.302")
 val versionToPublish by extra(mcJavaVersion)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -31,5 +31,5 @@
  *
  * For versions of Spine-based dependencies please see [io.spine.internal.dependency.spine].
  */
-val mcJavaVersion by extra("2.0.0-SNAPSHOT.302")
+val mcJavaVersion by extra("2.0.0-SNAPSHOT.303")
 val versionToPublish by extra(mcJavaVersion)


### PR DESCRIPTION
This PR fixes the issues with integrating a `KspBasedPlugin` into a Gradle project.

### Changes in details
 * Fixed adding `complyOnly` dependency on `com.google.auto.service:auto-service-annotations`.
 * Kotlin directory set for each source set now has `java` and `kotlin` subdirectories under `generated/ksp/` directory.
 * Simplified error processing in `CommonChecks.kt`.
 * The type of entity IDs is now resolved using the reference to `Entity.id()` method instead of climbing up the inheritance of an entity class.
